### PR TITLE
Add theme switcher with light and dark themes and user preference per…

### DIFF
--- a/client/src/common/components/MainLayout.tsx
+++ b/client/src/common/components/MainLayout.tsx
@@ -14,12 +14,13 @@ import {
   ListItemButton,
   ListItemText,
   ListItemIcon,
-  useTheme,
+  useTheme as useMuiTheme,
   useMediaQuery,
 } from '@mui/material';
 import { Theme } from '@mui/material/styles';
 import MenuIcon from '@mui/icons-material/Menu';
 import CustomUserButton from './CustomUserButton';
+import ThemeSwitcher from './ThemeSwitcher';
 import useUserRoles from '../hooks/useUserRoles';
 import { ROLES } from '../constants/roles';
 import InvoiceFileUpload from '../../modules/invoices/components/InvoiceFileUpload';
@@ -34,7 +35,7 @@ type NavItem = {
 };
 
 const MainLayout: React.FC = () => {
-  const theme = useTheme();
+  const theme = useMuiTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [mobileOpen, setMobileOpen] = useState(false);
   const userRoles = useUserRoles();
@@ -152,7 +153,8 @@ const MainLayout: React.FC = () => {
               ))}
             </Box>
 
-            <Box sx={{ ml: { xs: 1, md: 2 } }}>
+            <Box sx={{ ml: { xs: 1, md: 2 }, display: 'flex', alignItems: 'center' }}>
+              <ThemeSwitcher />
               <CustomUserButton afterSignOutUrl="/" />
             </Box>
           </Toolbar>

--- a/client/src/common/components/ThemeSwitcher.tsx
+++ b/client/src/common/components/ThemeSwitcher.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { IconButton, Tooltip } from '@mui/material';
+import LightModeIcon from '@mui/icons-material/LightMode';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import { useTheme } from '../../themes/ThemeContext';
+
+const ThemeSwitcher: React.FC = () => {
+  const { themeMode, setThemeMode, isLoading } = useTheme();
+
+  const handleToggleTheme = () => {
+    const newMode = themeMode === 'light' ? 'dark' : 'light';
+    setThemeMode(newMode);
+  };
+
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <Tooltip title={`Switch to ${themeMode === 'light' ? 'dark' : 'light'} mode`}>
+      <IconButton
+        onClick={handleToggleTheme}
+        color="inherit"
+        size="small"
+        sx={{
+          ml: 1,
+          transition: 'all 0.2s ease',
+          '&:hover': {
+            transform: 'scale(1.1)',
+          },
+        }}
+      >
+        {themeMode === 'light' ? <DarkModeIcon /> : <LightModeIcon />}
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export default ThemeSwitcher;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -89,7 +89,7 @@ const queryClient = new QueryClient({
   },
 });
 
-// eslint-disable-next-line react-refresh/only-export-components
+ 
 const RootComponent: React.FC = () => {
   return (
     <ThemeProvider>

--- a/client/src/modules/login/Login.tsx
+++ b/client/src/modules/login/Login.tsx
@@ -11,7 +11,6 @@ import {
   Stack,
   CircularProgress,
   Alert,
-  Theme,
 } from '@mui/material';
 import { useSignIn } from '@clerk/clerk-react';
 import { useState, FormEvent, ChangeEvent } from 'react';

--- a/client/src/themes/ThemeContext.tsx
+++ b/client/src/themes/ThemeContext.tsx
@@ -1,8 +1,92 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, createContext, useContext, useEffect, useState } from 'react';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material';
-import { theme } from './index';
+import { themes, ThemeMode } from './index';
+import axios from 'axios';
+import { useAuth, useUser } from '@clerk/clerk-react';
 
-// Simple theme provider with single theme
+interface ThemeContextType {
+  themeMode: ThemeMode;
+  setThemeMode: (mode: ThemeMode) => void;
+  isLoading: boolean;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};
+
 export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>;
+  const [themeMode, setThemeModeState] = useState<ThemeMode>('dark');
+  const [isLoading, setIsLoading] = useState(true);
+  const { isSignedIn, getToken } = useAuth();
+  const { user } = useUser();
+
+  // Load theme preference from API
+  useEffect(() => {
+    const loadThemePreference = async () => {
+      if (!isSignedIn || !user) {
+        setThemeModeState('dark'); // Default theme
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const token = await getToken();
+        const response = await axios.get('/users/me/theme-preference', {
+          headers: { Authorization: token },
+        });
+        
+        if (response.data?.themePreference) {
+          setThemeModeState(response.data.themePreference as ThemeMode);
+        }
+      } catch (error) {
+        console.warn('Failed to load theme preference:', error);
+        // Use dark as default fallback
+        setThemeModeState('dark');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadThemePreference();
+  }, [isSignedIn, user, getToken]);
+
+  // Save theme preference to API
+  const setThemeMode = async (mode: ThemeMode) => {
+    setThemeModeState(mode);
+
+    if (!isSignedIn || !user) {
+      return;
+    }
+
+    try {
+      const token = await getToken();
+      await axios.put(
+        '/users/me/theme-preference',
+        { themePreference: mode },
+        { headers: { Authorization: token } }
+      );
+    } catch (error) {
+      console.warn('Failed to save theme preference:', error);
+    }
+  };
+
+  const contextValue: ThemeContextType = {
+    themeMode,
+    setThemeMode,
+    isLoading,
+  };
+
+  return (
+    <ThemeContext.Provider value={contextValue}>
+      <MuiThemeProvider theme={themes[themeMode]}>
+        {children}
+      </MuiThemeProvider>
+    </ThemeContext.Provider>
+  );
 };

--- a/client/src/themes/index.ts
+++ b/client/src/themes/index.ts
@@ -1,6 +1,11 @@
 import { darkTheme } from './darkTheme';
+import { lightTheme } from './lightTheme';
 
-// Export the light theme as the default and only theme
-export const theme = darkTheme;
+export { darkTheme, lightTheme };
 
-export { darkTheme };
+export const themes = {
+  light: lightTheme,
+  dark: darkTheme,
+} as const;
+
+export type ThemeMode = keyof typeof themes;

--- a/client/src/themes/lightTheme.ts
+++ b/client/src/themes/lightTheme.ts
@@ -1,0 +1,191 @@
+import { createTheme } from '@mui/material';
+
+// Clean Light Theme
+export const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: {
+      main: '#1976D2',
+      light: '#42A5F5',
+      dark: '#1565C0',
+      contrastText: '#FFFFFF',
+    },
+    secondary: {
+      main: '#6B7280',
+      light: '#9CA3AF',
+      dark: '#4B5563',
+      contrastText: '#FFFFFF',
+    },
+    background: {
+      default: '#FAFAFA',
+      paper: '#FFFFFF',
+    },
+    text: {
+      primary: '#212121',
+      secondary: '#757575',
+    },
+    error: {
+      main: '#D32F2F',
+    },
+    warning: {
+      main: '#ED6C02',
+    },
+    info: {
+      main: '#0288D1',
+    },
+    success: {
+      main: '#2E7D32',
+    },
+    divider: 'rgba(0, 0, 0, 0.12)',
+  },
+  typography: {
+    fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+    h1: {
+      fontWeight: 700,
+    },
+    h2: {
+      fontWeight: 700,
+    },
+    h3: {
+      fontWeight: 600,
+    },
+    h4: {
+      fontWeight: 600,
+    },
+    h5: {
+      fontWeight: 600,
+    },
+    h6: {
+      fontWeight: 600,
+    },
+    button: {
+      fontWeight: 600,
+      textTransform: 'none',
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
+          padding: '8px 16px',
+          transition: 'all 0.2s ease',
+          '&:hover': {
+            boxShadow: '0 4px 6px rgba(0, 0, 0, 0.15)',
+            transform: 'translateY(-1px)',
+          },
+        },
+        contained: {
+          backgroundColor: '#1976D2',
+          color: '#FFFFFF',
+          '&:hover': {
+            backgroundColor: '#1565C0',
+          },
+        },
+        outlined: {
+          borderColor: 'rgba(0, 0, 0, 0.23)',
+          color: '#1976D2',
+          '&:hover': {
+            borderColor: '#1976D2',
+            backgroundColor: 'rgba(25, 118, 210, 0.04)',
+          },
+        },
+      },
+    },
+    MuiSelect: {
+      styleOverrides: {
+        root: {
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#1976D2',
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: 'rgba(0, 0, 0, 0.23)',
+          },
+        },
+      },
+    },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          '&.Mui-selected': {
+            backgroundColor: 'rgba(25, 118, 210, 0.08)',
+          },
+          '&.Mui-selected:hover': {
+            backgroundColor: 'rgba(25, 118, 210, 0.12)',
+          },
+          '&:hover': {
+            backgroundColor: 'rgba(0, 0, 0, 0.04)',
+          },
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24)',
+          border: '1px solid rgba(0, 0, 0, 0.12)',
+          backgroundImage: 'none',
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24)',
+        },
+      },
+    },
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12)',
+          backgroundImage: 'none',
+          backgroundColor: '#FFFFFF',
+          borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+        },
+      },
+    },
+    MuiTableHead: {
+      styleOverrides: {
+        root: {
+          '& .MuiTableCell-root': {
+            fontWeight: 600,
+            color: '#212121',
+            backgroundColor: '#F5F5F5',
+            borderBottom: '2px solid rgba(0, 0, 0, 0.12)',
+          },
+        },
+      },
+    },
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '& fieldset': {
+              borderColor: 'rgba(0, 0, 0, 0.23)',
+            },
+            '&:hover fieldset': {
+              borderColor: 'rgba(0, 0, 0, 0.4)',
+            },
+            '&.Mui-focused fieldset': {
+              borderColor: '#1976D2',
+            },
+          },
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          fontWeight: 500,
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
…sistence

- Create light theme configuration with clean Material-UI styling
- Implement enhanced theme context with support for theme switching
- Add theme switcher component in header with light/dark mode toggle
- Add theme preference field to User entity with database migration
- Implement API endpoints for getting and updating user theme preferences
- Integrate theme persistence with user account settings via API
- Update TypeScript interfaces and DTOs to support theme preference
- Fix import conflicts and linting issues

🤖 Generated with [Claude Code](https://claude.ai/code)