### PR TITLE
IA-23: Add email domain validation for @honeycombsoft.com

### DIFF
--- a/api/src/application/users/dto/create-user.dto.ts
+++ b/api/src/application/users/dto/create-user.dto.ts
@@ -9,15 +9,17 @@ import {
     ArrayMinSize,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsHoneycombEmail } from '../validators/honeycomb-email.validator';
 
 export class CreateUserDto {
     @ApiProperty({
-        description: 'Email address of the user',
-        example: 'user@example.com',
+        description: 'Email address of the user (must be from @honeycombsoft.com domain)',
+        example: 'user@honeycombsoft.com',
         maxLength: 255,
     })
     @IsNotEmpty()
     @IsEmail()
+    @IsHoneycombEmail()
     @MaxLength(255)
     email: string;
 

--- a/api/src/application/users/validators/honeycomb-email.validator.ts
+++ b/api/src/application/users/validators/honeycomb-email.validator.ts
@@ -1,0 +1,27 @@
+import { registerDecorator, ValidationOptions, ValidationArguments } from 'class-validator';
+
+export function IsHoneycombEmail(validationOptions?: ValidationOptions) {
+    return function (object: object, propertyName: string) {
+        registerDecorator({
+            name: 'isHoneycombEmail',
+            target: object.constructor,
+            propertyName: propertyName,
+            options: validationOptions,
+            validator: {
+                validate(value: unknown, _args: ValidationArguments) {
+                    if (typeof value !== 'string') {
+                        return false;
+                    }
+
+                    // Case-insensitive check for @honeycombsoft.com domain
+                    // Only exact domain allowed, no subdomains
+                    const emailRegex = /^[^\s@]+@honeycombsoft\.com$/i;
+                    return emailRegex.test(value);
+                },
+                defaultMessage(_args: ValidationArguments) {
+                    return 'Email must be from @honeycombsoft.com domain';
+                },
+            },
+        });
+    };
+}

--- a/client/src/modules/users/components/UserForm.tsx
+++ b/client/src/modules/users/components/UserForm.tsx
@@ -56,7 +56,15 @@ const generateUserSchema = (allRoles: Role[]) =>
   Yup.object().shape({
     firstName: Yup.string().max(100, 'Too Long!').optional(),
     lastName: Yup.string().max(100, 'Too Long!').optional(),
-    email: Yup.string().email('Invalid email').max(255).required('Required'),
+    email: Yup.string()
+      .email('Invalid email')
+      .max(255)
+      .required('Required')
+      .test('honeycomb-domain', 'Email must be from @honeycombsoft.com domain', (value) => {
+        if (!value) return false;
+        // Case-insensitive check for @honeycombsoft.com domain
+        return value.toLowerCase().endsWith('@honeycombsoft.com');
+      }),
     tenantId: Yup.string().when(['roleIds', '$isSuperAdmin'], {
       is: (roleIds: string[], isContextSuperAdmin: boolean) => {
         const superAdminRole = allRoles?.find((r) => r.name === ROLES.SUPER_ADMIN);
@@ -238,7 +246,8 @@ const UserForm: React.FC<UserFormProps> = ({ user, onClose }) => {
               <Field
                 as={TextField}
                 name="email"
-                label="Email"
+                label="Email (@honeycombsoft.com)"
+                placeholder="user@honeycombsoft.com"
                 type="email"
                 fullWidth
                 required


### PR DESCRIPTION
## Summary
- Added email domain validation to enforce @honeycombsoft.com domain for new users
- Implemented case-insensitive validation that only accepts exact domain (no subdomains)
- Applied validation to both regular user creation and super admin user creation endpoints

## Changes
- **Backend**: Added custom `IsHoneycombEmail` validator for email domain validation
- **Backend**: Updated `CreateUserDto` to use the new validator
- **Frontend**: Added Yup validation for email domain in `UserForm` component
- **Frontend**: Updated UI to show domain requirement in email field placeholder and label

## Additional Context from User Q&A
- **Domain validation**: Case-insensitive (accepts honeycombsoft.com and HONEYCOMBSOFT.COM)
- **Existing users**: No impact on existing users with non-honeycombsoft.com emails
- **Subdomain support**: Only exact domain @honeycombsoft.com allowed (no subdomains)
- **Endpoints affected**: Both regular user creation (POST /users) and super admin user creation (POST /users/super)

## Test Plan
- [ ] Create a new user with @honeycombsoft.com email - should succeed
- [ ] Create a new user with @HONEYCOMBSOFT.COM email - should succeed (case-insensitive)
- [ ] Create a new user with non-honeycombsoft.com email - should fail with validation error
- [ ] Create a new user with subdomain (e.g., @dev.honeycombsoft.com) - should fail
- [ ] Verify existing users with non-honeycombsoft.com emails still work normally
- [ ] Test both regular admin and super admin user creation flows