### PR TITLE
IA-32: Add a new Billing Contact field to the Tenant

### DIFF
--- a/api/src/application/tenants/dto/create-tenant.dto.ts
+++ b/api/src/application/tenants/dto/create-tenant.dto.ts
@@ -1,4 +1,12 @@
-import { IsNotEmpty, IsString, MaxLength, Matches, IsLowercase } from 'class-validator';
+import {
+    IsNotEmpty,
+    IsString,
+    MaxLength,
+    Matches,
+    IsLowercase,
+    IsOptional,
+    IsEmail,
+} from 'class-validator';
 import { ALIAS_PATTERN } from '../../../domain/constants/validation-patterns.const';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -28,4 +36,15 @@ export class CreateTenantDto {
         message: 'Alias must be lowercase alphanumeric with hyphens and no leading/trailing hyphen',
     })
     alias: string;
+
+    @ApiProperty({
+        description: 'Billing contact email address',
+        example: 'billing@acme-corp.com',
+        required: false,
+        maxLength: 255,
+    })
+    @IsOptional()
+    @IsEmail()
+    @MaxLength(255)
+    billingContact?: string;
 }

--- a/api/src/application/tenants/dto/tenant.dto.ts
+++ b/api/src/application/tenants/dto/tenant.dto.ts
@@ -19,4 +19,11 @@ export class TenantDto {
         example: 'acme-corp',
     })
     alias: string;
+
+    @ApiProperty({
+        description: 'Billing contact email address',
+        example: 'billing@acme-corp.com',
+        required: false,
+    })
+    billingContact?: string;
 }

--- a/api/src/application/tenants/dto/update-tenant.dto.ts
+++ b/api/src/application/tenants/dto/update-tenant.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsOptional, IsString, MaxLength, IsEmail } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateTenantDto {
@@ -12,4 +12,15 @@ export class UpdateTenantDto {
     @IsString()
     @MaxLength(255)
     name?: string;
+
+    @ApiProperty({
+        description: 'Billing contact email address',
+        example: 'billing@updated-corp.com',
+        required: false,
+        maxLength: 255,
+    })
+    @IsOptional()
+    @IsEmail()
+    @MaxLength(255)
+    billingContact?: string;
 }

--- a/api/src/domain/entities/tenant.entity.ts
+++ b/api/src/domain/entities/tenant.entity.ts
@@ -12,6 +12,9 @@ export class Tenant {
     @Column({ length: 50, unique: true })
     alias: string;
 
+    @Column({ type: 'varchar', length: 255, nullable: true })
+    billingContact?: string;
+
     @OneToMany(() => User, (user) => user.tenant)
     users?: User[];
 }

--- a/api/src/infrastructure/persistence/migrations/1749000000000-AddBillingContactToTenant.ts
+++ b/api/src/infrastructure/persistence/migrations/1749000000000-AddBillingContactToTenant.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddBillingContactToTenant1749000000000 implements MigrationInterface {
+    name = 'AddBillingContactToTenant1749000000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "tenants" ADD "billingContact" character varying(255)`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "tenants" DROP COLUMN "billingContact"`);
+    }
+}

--- a/client/src/modules/tenants/components/TenantForm.tsx
+++ b/client/src/modules/tenants/components/TenantForm.tsx
@@ -21,6 +21,7 @@ type TenantFormProps = {
 type TenantFormValues = {
   name: string;
   alias: string;
+  billingContact: string;
 };
 
 const TenantSchema = Yup.object().shape({
@@ -31,6 +32,7 @@ const TenantSchema = Yup.object().shape({
       message: 'Alias must be lowercase alphanumeric with hyphens (no leading/trailing)',
     })
     .required('Required'),
+  billingContact: Yup.string().email('Invalid email').max(255, 'Too Long!'),
 });
 
 const TenantForm: React.FC<TenantFormProps> = ({ tenant, onClose }) => {
@@ -71,16 +73,24 @@ const TenantForm: React.FC<TenantFormProps> = ({ tenant, onClose }) => {
     (): TenantFormValues => ({
       name: tenant?.name ?? '',
       alias: tenant?.alias ?? '',
+      billingContact: tenant?.billingContact ?? '',
     }),
     [tenant],
   );
 
   const handleSubmit = async (values: TenantFormValues): Promise<void> => {
     if (tenant) {
-      const updateData: UpdateTenantInput = { name: values.name };
+      const updateData: UpdateTenantInput = { 
+        name: values.name,
+        billingContact: values.billingContact || undefined,
+      };
       await updateTenantMutate({ id: tenant.id, data: updateData });
     } else {
-      const createPayload: CreateTenantInput = { name: values.name, alias: values.alias };
+      const createPayload: CreateTenantInput = { 
+        name: values.name, 
+        alias: values.alias,
+        billingContact: values.billingContact || undefined,
+      };
       await addTenantMutate(createPayload);
     }
   };
@@ -115,6 +125,16 @@ const TenantForm: React.FC<TenantFormProps> = ({ tenant, onClose }) => {
                 disabled={!!tenant}
                 error={touched.alias && !!errors.alias}
                 helperText={touched.alias && errors.alias}
+              />
+              <Field
+                as={TextField}
+                name="billingContact"
+                label="Billing Contact Email (optional)"
+                variant="outlined"
+                fullWidth
+                type="email"
+                error={touched.billingContact && !!errors.billingContact}
+                helperText={touched.billingContact && errors.billingContact}
               />
 
               <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mt: 3 }}>

--- a/client/src/modules/tenants/tenant-management/TenantManagementPage.tsx
+++ b/client/src/modules/tenants/tenant-management/TenantManagementPage.tsx
@@ -134,6 +134,7 @@ const TenantManagementPage: React.FC<TenantManagementPageProps> = () => {
                     }}>
                     <TableCell>Tenant Name</TableCell>
                     <TableCell>Alias</TableCell>
+                    <TableCell>Billing Contact</TableCell>
                     <TableCell align="right">Actions</TableCell>
                   </TableRow>
                 </TableHead>
@@ -153,7 +154,7 @@ const TenantManagementPage: React.FC<TenantManagementPageProps> = () => {
                   }}>
                   {tenants.length === 0 && !isLoading && (
                     <TableRow>
-                      <TableCell colSpan={4} align="center" sx={{ py: 3 }}>
+                      <TableCell colSpan={5} align="center" sx={{ py: 3 }}>
                         No tenants found.
                       </TableCell>
                     </TableRow>
@@ -164,6 +165,7 @@ const TenantManagementPage: React.FC<TenantManagementPageProps> = () => {
                         {tenant.name}
                       </TableCell>
                       <TableCell>{tenant.alias}</TableCell>
+                      <TableCell>{tenant.billingContact || '-'}</TableCell>
                       <TableCell align="right">
                         <Button
                           variant="text"

--- a/client/src/modules/tenants/tenantMutations.ts
+++ b/client/src/modules/tenants/tenantMutations.ts
@@ -4,10 +4,12 @@ import axios from 'axios';
 export type CreateTenantInput = {
   name: string;
   alias: string;
+  billingContact?: string;
 };
 
 export type UpdateTenantInput = {
-  name: string;
+  name?: string;
+  billingContact?: string;
 };
 
 export type UpdateTenantPayload = {

--- a/client/src/modules/tenants/types/tenant.ts
+++ b/client/src/modules/tenants/types/tenant.ts
@@ -2,4 +2,5 @@ export type Tenant = {
   id: string;
   name: string;
   alias: string;
+  billingContact?: string;
 };


### PR DESCRIPTION
## Summary
- Added optional billing contact email field to Tenant entity
- Updated frontend forms and table to display/edit billing contact
- Created database migration for the new field

## Implementation Details
- Added `billingContact` field as optional varchar(255) to Tenant entity
- Email validation on both backend (class-validator) and frontend (Yup)
- Field is editable by all admin roles (ADMIN and SUPER_ADMIN)
- Shows as "-" in the table when no billing contact is set

## Test plan
- [ ] Create a new tenant without billing contact
- [ ] Create a new tenant with billing contact email
- [ ] Edit existing tenant to add billing contact
- [ ] Edit existing tenant to update billing contact
- [ ] Verify email validation works (invalid emails are rejected)
- [ ] Verify billing contact displays correctly in tenant table
- [ ] Run database migration and verify schema changes