### PR TITLE
IA-33: Add validation for @honeycombsoft.com email domain

### DIFF
--- a/api/src/application/users/dto/update-user.dto.ts
+++ b/api/src/application/users/dto/update-user.dto.ts
@@ -8,16 +8,18 @@ import {
     IsNotEmpty,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsHoneycombEmail } from '../validators/honeycomb-email.validator';
 
 export class UpdateUserDto {
     @ApiProperty({
-        description: 'Email address of the user',
-        example: 'updated@example.com',
+        description: 'Email address of the user (must be from @honeycombsoft.com domain)',
+        example: 'updated@honeycombsoft.com',
         required: false,
         maxLength: 255,
     })
     @IsOptional()
     @IsEmail()
+    @IsHoneycombEmail()
     @MaxLength(255)
     email?: string;
 

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -89,7 +89,7 @@ const queryClient = new QueryClient({
   },
 });
 
-// eslint-disable-next-line react-refresh/only-export-components
+ 
 const RootComponent: React.FC = () => {
   return (
     <ThemeProvider>

--- a/client/src/modules/login/Login.tsx
+++ b/client/src/modules/login/Login.tsx
@@ -11,7 +11,6 @@ import {
   Stack,
   CircularProgress,
   Alert,
-  Theme,
 } from '@mui/material';
 import { useSignIn } from '@clerk/clerk-react';
 import { useState, FormEvent, ChangeEvent } from 'react';


### PR DESCRIPTION
## Summary
- Added email domain validation to ensure only @honeycombsoft.com addresses are accepted
- Applied validation to both create and update user operations
- Frontend already had validation, backend update endpoint was missing it

## Changes
- Added `@IsHoneycombEmail()` validator to `UpdateUserDto` in the API
- Updated API documentation to reflect the domain requirement
- Fixed minor linting issues in client code

## Testing
- ✅ API linting passes
- ✅ Client linting passes
- ✅ All tests pass (no test failures)
- ✅ Validation is consistent across create and update operations

## Impact
- Users can only be created or updated with @honeycombsoft.com email addresses
- Existing validation on frontend UserForm component remains unchanged
- Backend now enforces the same validation rules for updates