### PR TITLE
IA-35: We need to add validation when creating/adding a new user. Only email addresses from the @honeycombsoft.com domain should be accepted

### DIFF
--- a/api/src/application/users/dto/create-user.dto.ts
+++ b/api/src/application/users/dto/create-user.dto.ts
@@ -9,15 +9,19 @@ import {
     ArrayMinSize,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsEmailFromDomain } from '../validators/email-domain.validator';
 
 export class CreateUserDto {
     @ApiProperty({
-        description: 'Email address of the user',
-        example: 'user@example.com',
+        description: 'Email address of the user (must be from @honeycombsoft.com domain)',
+        example: 'user@honeycombsoft.com',
         maxLength: 255,
     })
     @IsNotEmpty()
     @IsEmail()
+    @IsEmailFromDomain('honeycombsoft.com', {
+        message: 'Email must be from the @honeycombsoft.com domain',
+    })
     @MaxLength(255)
     email: string;
 

--- a/api/src/application/users/validators/email-domain.validator.ts
+++ b/api/src/application/users/validators/email-domain.validator.ts
@@ -1,0 +1,29 @@
+import { registerDecorator, ValidationOptions, ValidationArguments } from 'class-validator';
+
+export function IsEmailFromDomain(domain: string, validationOptions?: ValidationOptions) {
+    return function (object: object, propertyName: string) {
+        registerDecorator({
+            name: 'isEmailFromDomain',
+            target: object.constructor,
+            propertyName: propertyName,
+            constraints: [domain],
+            options: validationOptions,
+            validator: {
+                validate(value: unknown, args: ValidationArguments) {
+                    const [allowedDomain] = args.constraints as string[];
+                    if (typeof value !== 'string') return false;
+
+                    const emailParts = value.split('@');
+                    if (emailParts.length !== 2) return false;
+
+                    const emailDomain = emailParts[1];
+                    return emailDomain === allowedDomain;
+                },
+                defaultMessage(args: ValidationArguments) {
+                    const [allowedDomain] = args.constraints as string[];
+                    return `Email must be from the @${allowedDomain} domain`;
+                },
+            },
+        });
+    };
+}

--- a/client/src/modules/users/components/UserForm.tsx
+++ b/client/src/modules/users/components/UserForm.tsx
@@ -56,7 +56,16 @@ const generateUserSchema = (allRoles: Role[]) =>
   Yup.object().shape({
     firstName: Yup.string().max(100, 'Too Long!').optional(),
     lastName: Yup.string().max(100, 'Too Long!').optional(),
-    email: Yup.string().email('Invalid email').max(255).required('Required'),
+    email: Yup.string()
+      .email('Invalid email')
+      .max(255)
+      .required('Required')
+      .test('email-domain', 'Email must be from the @honeycombsoft.com domain', (value) => {
+        if (!value) return false;
+        const emailParts = value.split('@');
+        if (emailParts.length !== 2) return false;
+        return emailParts[1] === 'honeycombsoft.com';
+      }),
     tenantId: Yup.string().when(['roleIds', '$isSuperAdmin'], {
       is: (roleIds: string[], isContextSuperAdmin: boolean) => {
         const superAdminRole = allRoles?.find((r) => r.name === ROLES.SUPER_ADMIN);


### PR DESCRIPTION
## Summary
- Added email domain validation to ensure only @honeycombsoft.com email addresses are accepted when creating users
- Implemented validation on both backend API and frontend forms

## Changes
- Created custom email domain validator for NestJS backend
- Updated CreateUserDto to enforce @honeycombsoft.com domain requirement
- Modified frontend UserForm component to validate email domain before submission
- Added user-friendly error messages for invalid email domains

## Test Plan
- [ ] Create a user with @honeycombsoft.com email - should succeed
- [ ] Try to create a user with non-@honeycombsoft.com email - should show validation error
- [ ] Validation works in both frontend form and backend API
- [ ] Error messages clearly indicate the domain requirement