### PR TITLE
IA-37: Add filters to User Management

### DIFF
--- a/client/src/modules/users/components/UserFilters.tsx
+++ b/client/src/modules/users/components/UserFilters.tsx
@@ -1,0 +1,226 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  OutlinedInput,
+  Select,
+  SelectChangeEvent,
+  TextField,
+  Chip,
+  useTheme,
+} from '@mui/material';
+import { useUserManagementStore } from '../stores/userManagementStore';
+import { User } from '../types/user';
+import { ROLES } from '../../../common/constants/roles';
+import useUserRoles from '../../../common/hooks/useUserRoles';
+
+interface UserFiltersProps {
+  users: User[];
+}
+
+const ITEM_HEIGHT = 48;
+const ITEM_PADDING_TOP = 8;
+const MenuProps = {
+  PaperProps: {
+    style: {
+      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+      width: 250,
+    },
+  },
+};
+
+const UserFilters: React.FC<UserFiltersProps> = ({ users }) => {
+  const theme = useTheme();
+  const { filters, updateFilters, clearFilters } = useUserManagementStore();
+  const userRoles = useUserRoles();
+  const isSuperAdmin = userRoles.includes(ROLES.SUPER_ADMIN);
+
+  const availableOptions = useMemo(() => {
+    const tenants = Array.from(new Set(users.map(u => u.tenant?.name).filter(Boolean)))
+      .sort();
+    const roles = Array.from(new Set(users.flatMap(u => u.roles?.map(r => r.name) || [])))
+      .sort();
+    
+    return { tenants, roles };
+  }, [users]);
+
+  const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    updateFilters({ email: event.target.value });
+  };
+
+  const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    updateFilters({ name: event.target.value });
+  };
+
+  const handleTenantChange = (event: SelectChangeEvent) => {
+    updateFilters({ tenant: event.target.value });
+  };
+
+  const handleRolesChange = (event: SelectChangeEvent<string[]>) => {
+    const value = event.target.value;
+    updateFilters({ roles: typeof value === 'string' ? value.split(',') : value });
+  };
+
+  const handleStatusChange = (event: SelectChangeEvent) => {
+    updateFilters({ status: event.target.value as 'all' | 'active' | 'inactive' });
+  };
+
+  const handleDateFromChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    updateFilters({ dateFrom: event.target.value });
+  };
+
+  const handleDateToChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    updateFilters({ dateTo: event.target.value });
+  };
+
+  const handleClearFilters = () => {
+    clearFilters();
+  };
+
+  const hasActiveFilters = Object.values(filters).some(value => 
+    Array.isArray(value) ? value.length > 0 : value !== '' && value !== 'all'
+  );
+
+  return (
+    <Card 
+      sx={{ 
+        mb: 2,
+        backgroundColor: theme.palette.background.paper,
+        color: theme.palette.text.primary,
+      }}
+    >
+      <CardContent>
+          <Grid container spacing={2} alignItems="center">
+            <Grid item xs={12} sm={6} md={2}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Email"
+                value={filters.email}
+                onChange={handleEmailChange}
+                variant="outlined"
+              />
+            </Grid>
+            
+            <Grid item xs={12} sm={6} md={2}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Name"
+                value={filters.name}
+                onChange={handleNameChange}
+                variant="outlined"
+              />
+            </Grid>
+
+            {isSuperAdmin && (
+              <Grid item xs={12} sm={6} md={2}>
+                <FormControl fullWidth size="small">
+                  <InputLabel>Tenant</InputLabel>
+                  <Select
+                    value={filters.tenant}
+                    onChange={handleTenantChange}
+                    input={<OutlinedInput label="Tenant" />}
+                  >
+                    <MenuItem value="">All</MenuItem>
+                    {availableOptions.tenants.map((tenant) => (
+                      <MenuItem key={tenant} value={tenant}>
+                        {tenant}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Grid>
+            )}
+
+            <Grid item xs={12} sm={6} md={2}>
+              <FormControl fullWidth size="small">
+                <InputLabel>Roles</InputLabel>
+                <Select
+                  multiple
+                  value={filters.roles}
+                  onChange={handleRolesChange}
+                  input={<OutlinedInput label="Roles" />}
+                  renderValue={(selected) => (
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                      {selected.map((value) => (
+                        <Chip key={value} label={value} size="small" />
+                      ))}
+                    </Box>
+                  )}
+                  MenuProps={MenuProps}
+                >
+                  {availableOptions.roles.map((role) => (
+                    <MenuItem key={role} value={role}>
+                      {role}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+
+            <Grid item xs={12} sm={6} md={2}>
+              <FormControl fullWidth size="small">
+                <InputLabel>Status</InputLabel>
+                <Select
+                  value={filters.status}
+                  onChange={handleStatusChange}
+                  input={<OutlinedInput label="Status" />}
+                >
+                  <MenuItem value="all">All</MenuItem>
+                  <MenuItem value="active">Active</MenuItem>
+                  <MenuItem value="inactive">Inactive</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
+
+            <Grid item xs={12} sm={6} md={2}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Created From"
+                type="date"
+                value={filters.dateFrom}
+                onChange={handleDateFromChange}
+                InputLabelProps={{ shrink: true }}
+                variant="outlined"
+              />
+            </Grid>
+
+            <Grid item xs={12} sm={6} md={2}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Created To"
+                type="date"
+                value={filters.dateTo}
+                onChange={handleDateToChange}
+                InputLabelProps={{ shrink: true }}
+                variant="outlined"
+              />
+            </Grid>
+
+            <Grid item xs={12} sm={6} md={2}>
+              <Button
+                fullWidth
+                variant="outlined"
+                onClick={handleClearFilters}
+                disabled={!hasActiveFilters}
+                sx={{ height: '40px' }}
+              >
+                Clear Filters
+              </Button>
+            </Grid>
+          </Grid>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default UserFilters;

--- a/client/src/modules/users/stores/userManagementStore.ts
+++ b/client/src/modules/users/stores/userManagementStore.ts
@@ -1,6 +1,16 @@
 import { create } from 'zustand';
 import { User } from '../types/user';
 
+interface UserFilters {
+  email: string;
+  name: string;
+  tenant: string;
+  roles: string[];
+  status: 'all' | 'active' | 'inactive';
+  dateFrom: string;
+  dateTo: string;
+}
+
 interface UserManagementState {
   isFormOpen: boolean;
   selectedUser: User | null;
@@ -8,6 +18,7 @@ interface UserManagementState {
   userToDeleteId: string | null;
   isConfirmToggleStatusDialogOpen: boolean;
   userToToggleStatus: User | null;
+  filters: UserFilters;
 
   openCreateForm: () => void;
   openEditForm: (user: User) => void;
@@ -20,7 +31,20 @@ interface UserManagementState {
   openConfirmToggleStatusDialog: (user: User) => void;
   closeConfirmToggleStatusDialog: () => void;
   resetToggleStatusState: () => void;
+
+  updateFilters: (filters: Partial<UserFilters>) => void;
+  clearFilters: () => void;
 }
+
+const initialFilters: UserFilters = {
+  email: '',
+  name: '',
+  tenant: '',
+  roles: [],
+  status: 'all',
+  dateFrom: '',
+  dateTo: '',
+};
 
 export const useUserManagementStore = create<UserManagementState>((set) => ({
   // Initial state
@@ -30,6 +54,7 @@ export const useUserManagementStore = create<UserManagementState>((set) => ({
   userToDeleteId: null,
   isConfirmToggleStatusDialogOpen: false,
   userToToggleStatus: null,
+  filters: initialFilters,
 
   openCreateForm: (): void => set({ isFormOpen: true, selectedUser: null }),
   openEditForm: (user: User): void => set({ isFormOpen: true, selectedUser: user }),
@@ -47,4 +72,8 @@ export const useUserManagementStore = create<UserManagementState>((set) => ({
     set({ isConfirmToggleStatusDialogOpen: false, userToToggleStatus: null }),
   resetToggleStatusState: (): void =>
     set({ isConfirmToggleStatusDialogOpen: false, userToToggleStatus: null }),
+
+  updateFilters: (filters: Partial<UserFilters>): void =>
+    set((state) => ({ filters: { ...state.filters, ...filters } })),
+  clearFilters: (): void => set({ filters: initialFilters }),
 }));

--- a/client/src/modules/users/user-management/UserManagementPage.tsx
+++ b/client/src/modules/users/user-management/UserManagementPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useSnackbar } from 'notistack';
 import {
   Box,
@@ -28,8 +28,10 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { isAfter, isBefore, parseISO, isValid } from 'date-fns';
 import { User } from '../types/user.ts';
 import UserForm from '../components/UserForm.tsx';
+import UserFilters from '../components/UserFilters.tsx';
 import ConfirmationDialog from '../../../common/components/ConfirmationDialog.tsx';
 import useUserRoles from '../../../common/hooks/useUserRoles';
 import { ROLES } from '../../../common/constants/roles';
@@ -69,6 +71,7 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
     userToDeleteId,
     isConfirmToggleStatusDialogOpen,
     userToToggleStatus,
+    filters,
     openCreateForm,
     openEditForm,
     closeForm,
@@ -98,7 +101,59 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
     }
   }, [usersError, enqueueSnackbar]);
 
-  const users: User[] = usersData?.data ?? [];
+  const allUsers: User[] = usersData?.data ?? [];
+
+  const filteredUsers: User[] = useMemo(() => {
+    return allUsers.filter((user) => {
+      if (filters.email && !user.email.toLowerCase().includes(filters.email.toLowerCase())) {
+        return false;
+      }
+
+      const fullName = `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim().toLowerCase();
+      if (filters.name && !fullName.includes(filters.name.toLowerCase())) {
+        return false;
+      }
+
+      if (filters.tenant && user.tenant?.name !== filters.tenant) {
+        return false;
+      }
+
+      if (filters.roles.length > 0) {
+        const userRoleNames = user.roles?.map(role => role.name) || [];
+        const hasAnyRole = filters.roles.some(filterRole => userRoleNames.includes(filterRole));
+        if (!hasAnyRole) {
+          return false;
+        }
+      }
+
+      if (filters.status !== 'all') {
+        const isActive = filters.status === 'active';
+        if (user.isActive !== isActive) {
+          return false;
+        }
+      }
+
+      if (filters.dateFrom) {
+        const fromDate = parseISO(filters.dateFrom);
+        const userDate = parseISO(user.createdAt);
+        if (isValid(fromDate) && isValid(userDate) && isBefore(userDate, fromDate)) {
+          return false;
+        }
+      }
+
+      if (filters.dateTo) {
+        const toDate = parseISO(filters.dateTo);
+        const userDate = parseISO(user.createdAt);
+        if (isValid(toDate) && isValid(userDate) && isAfter(userDate, toDate)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [allUsers, filters]);
+
+  const users = filteredUsers;
 
   const { mutateAsync: removeUserMutate, isPending: isDeleting } = useMutation({
     mutationFn: deleteUser,
@@ -176,6 +231,9 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
             </Button>
           }
         />
+        <Box sx={{ p: 2, borderBottom: `1px solid ${theme.palette.divider}` }}>
+          <UserFilters users={allUsers} />
+        </Box>
         <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
           {isLoading && (
             <Box sx={{ display: 'flex', justifyContent: 'center', my: 5 }}>


### PR DESCRIPTION
## Summary
- Add comprehensive client-side filtering for all user table fields including email, name, tenant, roles, status, and creation date
- Implement individual filter controls (dropdowns, date pickers, text inputs) with responsive Material UI design
- Integrate filtering state management using existing Zustand store pattern

## Test plan
- [ ] Test email text filter with partial matches (case-insensitive)
- [ ] Test name text filter combining first and last names
- [ ] Test tenant dropdown filter (visible only to super admin users)
- [ ] Test multi-select roles filter with chip display
- [ ] Test status filter (all/active/inactive options)
- [ ] Test date range filtering for user creation dates
- [ ] Test clear filters functionality resets all filters
- [ ] Test responsive layout on different screen sizes
- [ ] Test filter persistence during page interactions
- [ ] Verify no breaking changes to existing user management functionality