### PR TITLE
IA-52: Add theme switcher

### DIFF
--- a/client/src/common/components/CustomUserButton.tsx
+++ b/client/src/common/components/CustomUserButton.tsx
@@ -11,11 +11,14 @@ import {
   ListItemButton,
   Divider,
   Tooltip,
-  useTheme,
+  useTheme as useMuiTheme,
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import LogoutIcon from '@mui/icons-material/Logout';
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import Brightness7Icon from '@mui/icons-material/Brightness7';
 import { useClerk, useUser } from '@clerk/clerk-react';
+import { useTheme } from '../../themes/ThemeContext';
 
 type CustomUserButtonProps = {
   afterSignOutUrl: string;
@@ -26,7 +29,8 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
   const buttonRef = useRef<HTMLDivElement>(null);
   const { signOut } = useClerk();
   const { user } = useUser();
-  const theme = useTheme();
+  const muiTheme = useMuiTheme();
+  const { themeMode, toggleTheme } = useTheme();
 
   const handleClick = (): void => {
     setAnchorEl(buttonRef.current);
@@ -60,11 +64,11 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
           cursor: 'pointer',
           borderRadius: '50%',
           padding: '2px',
-          transition: theme.transitions.create(['background-color', 'box-shadow'], {
-            duration: theme.transitions.duration.shortest,
+          transition: muiTheme.transitions.create(['background-color', 'box-shadow'], {
+            duration: muiTheme.transitions.duration.shortest,
           }),
           '&:hover': {
-            backgroundColor: theme.palette.action.hover,
+            backgroundColor: muiTheme.palette.action.hover,
           },
         }}>
         <Avatar
@@ -73,7 +77,7 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
           sx={{
             width: 36,
             height: 36,
-            border: `2px solid ${theme.palette.primary.main}`,
+            border: `2px solid ${muiTheme.palette.primary.main}`,
           }}
         />
       </Box>
@@ -97,7 +101,7 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
             pt: 2,
             pb: 1,
             border: '1px solid',
-            borderColor: theme.palette.divider,
+            borderColor: muiTheme.palette.divider,
             boxShadow: '0 4px 20px rgba(0, 0, 0, 0.15)',
             backgroundImage: 'none',
           },
@@ -116,7 +120,7 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
               width: 40,
               height: 40,
               mr: 1.5,
-              border: `2px solid ${theme.palette.primary.main}`,
+              border: `2px solid ${muiTheme.palette.primary.main}`,
             }}
           />
           <Box>
@@ -124,7 +128,7 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
               <Typography
                 variant="body1"
                 sx={{
-                  color: theme.palette.text.primary,
+                  color: muiTheme.palette.text.primary,
                   maxWidth: 220,
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
@@ -143,14 +147,30 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
         <List disablePadding>
           <ListItem disablePadding>
             <ListItemButton
+              onClick={toggleTheme}
+              sx={{
+                px: 2,
+                '&:hover': {
+                  backgroundColor: muiTheme.palette.action.hover,
+                },
+              }}>
+              <ListItemIcon sx={{ minWidth: 36, color: muiTheme.palette.primary.main }}>
+                {themeMode === 'dark' ? <Brightness7Icon fontSize="small" /> : <Brightness4Icon fontSize="small" />}
+              </ListItemIcon>
+              <ListItemText primary={themeMode === 'dark' ? 'Light mode' : 'Dark mode'} />
+            </ListItemButton>
+          </ListItem>
+
+          <ListItem disablePadding>
+            <ListItemButton
               onClick={handleManageAccount}
               sx={{
                 px: 2,
                 '&:hover': {
-                  backgroundColor: theme.palette.action.hover,
+                  backgroundColor: muiTheme.palette.action.hover,
                 },
               }}>
-              <ListItemIcon sx={{ minWidth: 36, color: theme.palette.primary.main }}>
+              <ListItemIcon sx={{ minWidth: 36, color: muiTheme.palette.primary.main }}>
                 <SettingsIcon fontSize="small" />
               </ListItemIcon>
               <ListItemText primary="Manage account" />
@@ -163,10 +183,10 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
               sx={{
                 px: 2,
                 '&:hover': {
-                  backgroundColor: theme.palette.action.hover,
+                  backgroundColor: muiTheme.palette.action.hover,
                 },
               }}>
-              <ListItemIcon sx={{ minWidth: 36, color: theme.palette.primary.main }}>
+              <ListItemIcon sx={{ minWidth: 36, color: muiTheme.palette.primary.main }}>
                 <LogoutIcon fontSize="small" />
               </ListItemIcon>
               <ListItemText primary="Sign out" />

--- a/client/src/themes/ThemeContext.tsx
+++ b/client/src/themes/ThemeContext.tsx
@@ -1,8 +1,56 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, createContext, useContext, useState, useEffect } from 'react';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material';
-import { theme } from './index';
+import { whiteTheme, darkTheme } from './index';
 
-// Simple theme provider with single theme
+type ThemeMode = 'light' | 'dark';
+
+interface ThemeContextType {
+  themeMode: ThemeMode;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const THEME_STORAGE_KEY = 'app-theme-mode';
+
+export const useTheme = (): ThemeContextType => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+};
+
 export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>;
+  const [themeMode, setThemeMode] = useState<ThemeMode>(() => {
+    try {
+      const storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+      if (storedTheme === 'dark' || storedTheme === 'light') {
+        return storedTheme;
+      }
+      return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    } catch {
+      return 'light';
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, themeMode);
+    } catch (error) {
+      console.error('Failed to save theme preference:', error);
+    }
+  }, [themeMode]);
+
+  const toggleTheme = (): void => {
+    setThemeMode((prevMode) => (prevMode === 'light' ? 'dark' : 'light'));
+  };
+
+  const theme = themeMode === 'light' ? whiteTheme : darkTheme;
+
+  return (
+    <ThemeContext.Provider value={{ themeMode, toggleTheme }}>
+      <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>
+    </ThemeContext.Provider>
+  );
 };


### PR DESCRIPTION
## Summary
- Added theme switcher with icon button (sun/moon) in user menu dropdown
- Theme preference persists across sessions via localStorage
- Respects system color scheme on initial load if no saved preference

## Changes
- Enhanced `ThemeContext` to support dynamic theme switching between light and dark modes
- Modified `CustomUserButton` to include theme toggle option with appropriate icons
- Added localStorage persistence for theme preference
- Falls back to system preference when no saved preference exists

## Test Plan
- [x] Theme toggle button appears in user menu dropdown
- [x] Clicking toggle switches between light and dark themes
- [x] Theme preference persists after browser refresh
- [x] Icons correctly show sun for dark mode and moon for light mode
- [x] All lint checks pass