### PR TITLE
IA-56: Add theme switcher

### DIFF
--- a/client/src/common/components/CustomUserButton.tsx
+++ b/client/src/common/components/CustomUserButton.tsx
@@ -11,11 +11,14 @@ import {
   ListItemButton,
   Divider,
   Tooltip,
-  useTheme,
+  useTheme as useMuiTheme,
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import LogoutIcon from '@mui/icons-material/Logout';
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import Brightness7Icon from '@mui/icons-material/Brightness7';
 import { useClerk, useUser } from '@clerk/clerk-react';
+import { useTheme } from '../../themes/ThemeContext';
 
 type CustomUserButtonProps = {
   afterSignOutUrl: string;
@@ -26,7 +29,8 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
   const buttonRef = useRef<HTMLDivElement>(null);
   const { signOut } = useClerk();
   const { user } = useUser();
-  const theme = useTheme();
+  const muiTheme = useMuiTheme();
+  const { mode, toggleTheme } = useTheme();
 
   const handleClick = (): void => {
     setAnchorEl(buttonRef.current);
@@ -47,6 +51,10 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
     handleClose();
   };
 
+  const handleToggleTheme = (): void => {
+    toggleTheme();
+  };
+
   const open = Boolean(anchorEl);
 
   return (
@@ -60,11 +68,11 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
           cursor: 'pointer',
           borderRadius: '50%',
           padding: '2px',
-          transition: theme.transitions.create(['background-color', 'box-shadow'], {
-            duration: theme.transitions.duration.shortest,
+          transition: muiTheme.transitions.create(['background-color', 'box-shadow'], {
+            duration: muiTheme.transitions.duration.shortest,
           }),
           '&:hover': {
-            backgroundColor: theme.palette.action.hover,
+            backgroundColor: muiTheme.palette.action.hover,
           },
         }}>
         <Avatar
@@ -73,7 +81,7 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
           sx={{
             width: 36,
             height: 36,
-            border: `2px solid ${theme.palette.primary.main}`,
+            border: `2px solid ${muiTheme.palette.primary.main}`,
           }}
         />
       </Box>
@@ -97,7 +105,7 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
             pt: 2,
             pb: 1,
             border: '1px solid',
-            borderColor: theme.palette.divider,
+            borderColor: muiTheme.palette.divider,
             boxShadow: '0 4px 20px rgba(0, 0, 0, 0.15)',
             backgroundImage: 'none',
           },
@@ -116,7 +124,7 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
               width: 40,
               height: 40,
               mr: 1.5,
-              border: `2px solid ${theme.palette.primary.main}`,
+              border: `2px solid ${muiTheme.palette.primary.main}`,
             }}
           />
           <Box>
@@ -124,7 +132,7 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
               <Typography
                 variant="body1"
                 sx={{
-                  color: theme.palette.text.primary,
+                  color: muiTheme.palette.text.primary,
                   maxWidth: 220,
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
@@ -147,13 +155,29 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
               sx={{
                 px: 2,
                 '&:hover': {
-                  backgroundColor: theme.palette.action.hover,
+                  backgroundColor: muiTheme.palette.action.hover,
                 },
               }}>
-              <ListItemIcon sx={{ minWidth: 36, color: theme.palette.primary.main }}>
+              <ListItemIcon sx={{ minWidth: 36, color: muiTheme.palette.primary.main }}>
                 <SettingsIcon fontSize="small" />
               </ListItemIcon>
               <ListItemText primary="Manage account" />
+            </ListItemButton>
+          </ListItem>
+
+          <ListItem disablePadding>
+            <ListItemButton
+              onClick={handleToggleTheme}
+              sx={{
+                px: 2,
+                '&:hover': {
+                  backgroundColor: muiTheme.palette.action.hover,
+                },
+              }}>
+              <ListItemIcon sx={{ minWidth: 36, color: muiTheme.palette.primary.main }}>
+                {mode === 'dark' ? <Brightness7Icon fontSize="small" /> : <Brightness4Icon fontSize="small" />}
+              </ListItemIcon>
+              <ListItemText primary={mode === 'dark' ? 'Light mode' : 'Dark mode'} />
             </ListItemButton>
           </ListItem>
 
@@ -163,10 +187,10 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
               sx={{
                 px: 2,
                 '&:hover': {
-                  backgroundColor: theme.palette.action.hover,
+                  backgroundColor: muiTheme.palette.action.hover,
                 },
               }}>
-              <ListItemIcon sx={{ minWidth: 36, color: theme.palette.primary.main }}>
+              <ListItemIcon sx={{ minWidth: 36, color: muiTheme.palette.primary.main }}>
                 <LogoutIcon fontSize="small" />
               </ListItemIcon>
               <ListItemText primary="Sign out" />

--- a/client/src/themes/ThemeContext.tsx
+++ b/client/src/themes/ThemeContext.tsx
@@ -1,8 +1,44 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, createContext, useContext, useState, useEffect } from 'react';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material';
-import { theme } from './index';
+import { darkTheme } from './darkTheme';
+import { lightTheme } from './lightTheme';
 
-// Simple theme provider with single theme
+type ThemeMode = 'light' | 'dark';
+
+interface ThemeContextType {
+  mode: ThemeMode;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+};
+
 export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>;
+  const [mode, setMode] = useState<ThemeMode>(() => {
+    const savedTheme = localStorage.getItem('themeMode');
+    return (savedTheme as ThemeMode) || 'dark';
+  });
+
+  useEffect(() => {
+    localStorage.setItem('themeMode', mode);
+  }, [mode]);
+
+  const toggleTheme = () => {
+    setMode((prevMode) => (prevMode === 'light' ? 'dark' : 'light'));
+  };
+
+  const theme = mode === 'light' ? lightTheme : darkTheme;
+
+  return (
+    <ThemeContext.Provider value={{ mode, toggleTheme }}>
+      <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>
+    </ThemeContext.Provider>
+  );
 };

--- a/client/src/themes/index.ts
+++ b/client/src/themes/index.ts
@@ -1,6 +1,8 @@
 import { darkTheme } from './darkTheme';
+import { lightTheme } from './lightTheme';
 
-// Export the light theme as the default and only theme
+// Export both themes - ThemeContext handles selection
+export { darkTheme, lightTheme };
+
+// Legacy export for backwards compatibility
 export const theme = darkTheme;
-
-export { darkTheme };

--- a/client/src/themes/lightTheme.ts
+++ b/client/src/themes/lightTheme.ts
@@ -1,0 +1,190 @@
+import { createTheme } from '@mui/material';
+
+export const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: {
+      main: '#1976D2',
+      light: '#42A5F5',
+      dark: '#1565C0',
+      contrastText: '#FFFFFF',
+    },
+    secondary: {
+      main: '#9CA3AF',
+      light: '#D1D5DB',
+      dark: '#6B7280',
+      contrastText: '#FFFFFF',
+    },
+    background: {
+      default: '#F5F5F5',
+      paper: '#FFFFFF',
+    },
+    text: {
+      primary: '#212121',
+      secondary: '#757575',
+    },
+    error: {
+      main: '#D32F2F',
+    },
+    warning: {
+      main: '#F57C00',
+    },
+    info: {
+      main: '#0288D1',
+    },
+    success: {
+      main: '#388E3C',
+    },
+    divider: 'rgba(0, 0, 0, 0.12)',
+  },
+  typography: {
+    fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+    h1: {
+      fontWeight: 700,
+    },
+    h2: {
+      fontWeight: 700,
+    },
+    h3: {
+      fontWeight: 600,
+    },
+    h4: {
+      fontWeight: 600,
+    },
+    h5: {
+      fontWeight: 600,
+    },
+    h6: {
+      fontWeight: 600,
+    },
+    button: {
+      fontWeight: 600,
+      textTransform: 'none',
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          boxShadow: '0 1px 2px rgba(0, 0, 0, 0.05)',
+          padding: '8px 16px',
+          transition: 'all 0.2s ease',
+          '&:hover': {
+            boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
+            transform: 'translateY(-1px)',
+          },
+        },
+        contained: {
+          backgroundColor: '#1976D2',
+          color: '#FFFFFF',
+          '&:hover': {
+            backgroundColor: '#1565C0',
+          },
+        },
+        outlined: {
+          borderColor: 'rgba(0, 0, 0, 0.23)',
+          color: '#1976D2',
+          '&:hover': {
+            borderColor: '#1976D2',
+            backgroundColor: 'rgba(25, 118, 210, 0.04)',
+          },
+        },
+      },
+    },
+    MuiSelect: {
+      styleOverrides: {
+        root: {
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#1976D2',
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: 'rgba(0, 0, 0, 0.23)',
+          },
+        },
+      },
+    },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          '&.Mui-selected': {
+            backgroundColor: 'rgba(25, 118, 210, 0.08)',
+          },
+          '&.Mui-selected:hover': {
+            backgroundColor: 'rgba(25, 118, 210, 0.12)',
+          },
+          '&:hover': {
+            backgroundColor: 'rgba(0, 0, 0, 0.04)',
+          },
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.06)',
+          border: '1px solid rgba(0, 0, 0, 0.08)',
+          backgroundImage: 'none',
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.06)',
+        },
+      },
+    },
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12)',
+          backgroundImage: 'none',
+          backgroundColor: '#FFFFFF',
+          borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+        },
+      },
+    },
+    MuiTableHead: {
+      styleOverrides: {
+        root: {
+          '& .MuiTableCell-root': {
+            fontWeight: 600,
+            color: '#212121',
+            backgroundColor: '#F5F5F5',
+            borderBottom: '2px solid rgba(0, 0, 0, 0.12)',
+          },
+        },
+      },
+    },
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '& fieldset': {
+              borderColor: 'rgba(0, 0, 0, 0.23)',
+            },
+            '&:hover fieldset': {
+              borderColor: 'rgba(0, 0, 0, 0.4)',
+            },
+            '&.Mui-focused fieldset': {
+              borderColor: '#1976D2',
+            },
+          },
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          fontWeight: 500,
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Implemented a theme switcher that allows users to toggle between dark and light modes
- Added sun/moon icons in the user dropdown menu for intuitive theme switching
- Theme preference persists across sessions using localStorage

## Changes Made
- Created light theme configuration with Material UI styling to complement the existing dark theme
- Updated ThemeContext to support dynamic theme switching with localStorage persistence
- Added theme toggle button to CustomUserButton dropdown with appropriate icons (sun for light mode, moon for dark mode)
- Exported both light and dark themes from the themes index file

## Test Plan
- [x] Click on the user avatar to open the dropdown menu
- [x] Click on the theme toggle button (shows "Light mode" when in dark mode, "Dark mode" when in light mode)
- [x] Verify the theme switches between dark and light modes
- [x] Refresh the page and verify the selected theme persists
- [x] Check that all components render correctly in both themes
- [x] Verify the theme toggle icon changes appropriately (sun/moon icons)