### PR TITLE
IA-59: Add ability to re-arrange columns using drag&drop

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@clerk/clerk-js": "^5.60.0",
         "@clerk/clerk-react": "^5.25.6",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^7.0.1",
@@ -740,6 +742,59 @@
         "clsx": "^1.2.1",
         "eventemitter3": "^5.0.1",
         "preact": "^10.24.2"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,8 @@
   "dependencies": {
     "@clerk/clerk-js": "^5.60.0",
     "@clerk/clerk-react": "^5.25.6",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^7.0.1",

--- a/client/src/modules/users/components/DraggableTableHead.tsx
+++ b/client/src/modules/users/components/DraggableTableHead.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  horizontalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import {
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { TableCell, TableHead, TableRow, TableSortLabel } from '@mui/material';
+import { useTheme } from '@mui/material';
+
+interface Column {
+  id: string;
+  label: string;
+  sortable: boolean;
+  align?: 'left' | 'right' | 'center';
+  width?: string | number;
+}
+
+interface DraggableTableCellProps {
+  column: Column;
+  sortBy: string | null;
+  sortOrder: 'asc' | 'desc';
+  onSort?: (columnId: string) => void;
+}
+
+const DraggableTableCell: React.FC<DraggableTableCellProps> = ({ column, sortBy, sortOrder, onSort }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: column.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    cursor: isDragging ? 'grabbing' : 'grab',
+    opacity: isDragging ? 0.5 : 1,
+    position: 'relative' as const,
+  };
+
+  return (
+    <TableCell
+      ref={setNodeRef}
+      style={style}
+      align={column.align}
+      width={column.width}
+      {...attributes}
+      {...listeners}
+    >
+      {column.sortable ? (
+        <TableSortLabel
+          active={sortBy === column.id}
+          direction={sortBy === column.id ? sortOrder : 'asc'}
+          onClick={() => onSort?.(column.id)}
+        >
+          {column.label}
+        </TableSortLabel>
+      ) : (
+        column.label
+      )}
+    </TableCell>
+  );
+};
+
+interface DraggableTableHeadProps {
+  columns: Column[];
+  columnOrder: string[];
+  sortBy: string | null;
+  sortOrder: 'asc' | 'desc';
+  onSort: (columnId: string) => void;
+  onReorder: (newOrder: string[]) => void;
+}
+
+const DraggableTableHead: React.FC<DraggableTableHeadProps> = ({
+  columns,
+  columnOrder,
+  sortBy,
+  sortOrder,
+  onSort,
+  onReorder,
+}) => {
+  const theme = useTheme();
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = columnOrder.indexOf(active.id as string);
+      const newIndex = columnOrder.indexOf(over.id as string);
+      const newOrder = arrayMove(columnOrder, oldIndex, newIndex);
+      onReorder(newOrder);
+    }
+  };
+
+  const orderedColumns = columnOrder.length > 0
+    ? columnOrder.map(id => columns.find(col => col.id === id)).filter(Boolean) as Column[]
+    : columns;
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <TableHead>
+        <TableRow
+          sx={{
+            '& th': {
+              backgroundColor: theme.palette.action.hover,
+              color: theme.palette.text.secondary,
+              fontWeight: 'bold',
+              borderBottom: `1px solid ${theme.palette.divider}`,
+            },
+          }}
+        >
+          <SortableContext
+            items={columnOrder.length > 0 ? columnOrder : columns.map(c => c.id)}
+            strategy={horizontalListSortingStrategy}
+          >
+            {orderedColumns.map((column) => (
+              <DraggableTableCell
+                key={column.id}
+                column={column}
+                sortBy={sortBy}
+                sortOrder={sortOrder}
+                onSort={onSort}
+              />
+            ))}
+          </SortableContext>
+        </TableRow>
+      </TableHead>
+    </DndContext>
+  );
+};
+
+export default DraggableTableHead;

--- a/client/src/modules/users/stores/userManagementStore.ts
+++ b/client/src/modules/users/stores/userManagementStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import { User } from '../types/user';
 
+const COLUMN_ORDER_STORAGE_KEY = 'userManagement_columnOrder';
+
 interface UserManagementState {
   isFormOpen: boolean;
   selectedUser: User | null;
@@ -8,6 +10,7 @@ interface UserManagementState {
   userToDeleteId: string | null;
   isConfirmToggleStatusDialogOpen: boolean;
   userToToggleStatus: User | null;
+  columnOrder: string[];
 
   openCreateForm: () => void;
   openEditForm: (user: User) => void;
@@ -20,6 +23,9 @@ interface UserManagementState {
   openConfirmToggleStatusDialog: (user: User) => void;
   closeConfirmToggleStatusDialog: () => void;
   resetToggleStatusState: () => void;
+
+  setColumnOrder: (order: string[]) => void;
+  loadColumnOrder: () => void;
 }
 
 export const useUserManagementStore = create<UserManagementState>((set) => ({
@@ -30,6 +36,7 @@ export const useUserManagementStore = create<UserManagementState>((set) => ({
   userToDeleteId: null,
   isConfirmToggleStatusDialogOpen: false,
   userToToggleStatus: null,
+  columnOrder: [],
 
   openCreateForm: (): void => set({ isFormOpen: true, selectedUser: null }),
   openEditForm: (user: User): void => set({ isFormOpen: true, selectedUser: user }),
@@ -47,4 +54,23 @@ export const useUserManagementStore = create<UserManagementState>((set) => ({
     set({ isConfirmToggleStatusDialogOpen: false, userToToggleStatus: null }),
   resetToggleStatusState: (): void =>
     set({ isConfirmToggleStatusDialogOpen: false, userToToggleStatus: null }),
+
+  setColumnOrder: (order: string[]): void => {
+    localStorage.setItem(COLUMN_ORDER_STORAGE_KEY, JSON.stringify(order));
+    set({ columnOrder: order });
+  },
+
+  loadColumnOrder: (): void => {
+    const stored = localStorage.getItem(COLUMN_ORDER_STORAGE_KEY);
+    if (stored) {
+      try {
+        const order = JSON.parse(stored);
+        if (Array.isArray(order)) {
+          set({ columnOrder: order });
+        }
+      } catch (e) {
+        console.error('Failed to load column order from localStorage', e);
+      }
+    }
+  },
 }));


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Implemented drag & drop column reordering for the User Management table
- Column order persists across page refreshes using localStorage
- All columns including role-based conditional columns can be reordered

## Implementation Details
- Added `@dnd-kit/sortable` library for drag & drop functionality
- Created `DraggableTableHead` component that wraps table headers with drag & drop capabilities
- Updated `userManagementStore` to manage column order state with localStorage persistence
- Modified `UserManagementPage` to use the new draggable table headers and render cells according to column order

## Testing
- Columns can be dragged and reordered by clicking and dragging the column headers
- Column order persists after page refresh (stored in localStorage)
- Sorting functionality remains intact and works with reordered columns
- Super admin's tenant column can be reordered like any other column
- No columns can be hidden, only reordered

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)