### PR TITLE
IA-65: add validation to user email - only gmail.com domain should be accepted

### DIFF
--- a/client/src/modules/users/components/UserForm.tsx
+++ b/client/src/modules/users/components/UserForm.tsx
@@ -56,7 +56,15 @@ const generateUserSchema = (allRoles: Role[]) =>
   Yup.object().shape({
     firstName: Yup.string().max(100, 'Too Long!').optional(),
     lastName: Yup.string().max(100, 'Too Long!').optional(),
-    email: Yup.string().email('Invalid email').max(255).required('Required'),
+    email: Yup.string()
+      .email('Invalid email')
+      .max(255)
+      .required('Required')
+      .test('domain', 'Invalid email domain. Please use your @gmail.com email address', function(value) {
+        if (!value) return true; // Let required() handle empty values
+        const domain = value.split('@')[1];
+        return domain && domain.toLowerCase() === 'gmail.com';
+      }),
     tenantId: Yup.string().when(['roleIds', '$isSuperAdmin'], {
       is: (roleIds: string[], isContextSuperAdmin: boolean) => {
         const superAdminRole = allRoles?.find((r) => r.name === ROLES.SUPER_ADMIN);


### PR DESCRIPTION
## Summary

- Added email domain validation to UserForm component to only allow @gmail.com email addresses
- Implemented frontend-only validation using Yup schema with custom test method
- Case-insensitive domain matching for gmail.com
- Custom error message: "Invalid email domain. Please use your @gmail.com email address"

## Changes Made

- Modified `client/src/modules/users/components/UserForm.tsx` to add domain validation in the Yup schema
- Updated email validation to check for @gmail.com domain specifically
- Validation applies to both user creation and update operations
- No exemptions for super admins as per requirements

## Test Plan

- [x] Build passes without TypeScript errors
- [x] ESLint passes without warnings
- [x] Email validation schema correctly rejects non-gmail.com domains
- [x] Email validation allows valid @gmail.com addresses
- [x] Error message displays correctly for invalid domains

## Technical Details

The validation uses Yup's `.test()` method to add custom domain validation after standard email format validation. The implementation:

1. Checks if value exists (lets `required()` handle empty values)
2. Extracts domain from email using `split('@')[1]`
3. Performs case-insensitive comparison with 'gmail.com'
4. Returns boolean result for validation

This approach ensures existing email format validation remains intact while adding the domain restriction.