### PR TITLE
IA-66: add validation to user email - domain only honeycombsoft.com

### DIFF
--- a/api/src/application/users/dto/create-user.dto.ts
+++ b/api/src/application/users/dto/create-user.dto.ts
@@ -7,18 +7,22 @@ import {
     IsArray,
     ArrayNotEmpty,
     ArrayMinSize,
+    Matches,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateUserDto {
     @ApiProperty({
         description: 'Email address of the user',
-        example: 'user@example.com',
+        example: 'user@honeycombsoft.com',
         maxLength: 255,
     })
     @IsNotEmpty()
     @IsEmail()
     @MaxLength(255)
+    @Matches(/@honeycombsoft\.com$/i, {
+        message: 'Invalid email domain. Please use your @honeycombsoft.com email address',
+    })
     email: string;
 
     @ApiProperty({

--- a/api/src/application/users/dto/update-user.dto.ts
+++ b/api/src/application/users/dto/update-user.dto.ts
@@ -6,19 +6,23 @@ import {
     IsArray,
     ArrayMinSize,
     IsNotEmpty,
+    Matches,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateUserDto {
     @ApiProperty({
         description: 'Email address of the user',
-        example: 'updated@example.com',
+        example: 'updated@honeycombsoft.com',
         required: false,
         maxLength: 255,
     })
     @IsOptional()
     @IsEmail()
     @MaxLength(255)
+    @Matches(/@honeycombsoft\.com$/i, {
+        message: 'Invalid email domain. Please use your @honeycombsoft.com email address',
+    })
     email?: string;
 
     @ApiProperty({

--- a/client/src/modules/users/components/UserForm.tsx
+++ b/client/src/modules/users/components/UserForm.tsx
@@ -56,7 +56,15 @@ const generateUserSchema = (allRoles: Role[]) =>
   Yup.object().shape({
     firstName: Yup.string().max(100, 'Too Long!').optional(),
     lastName: Yup.string().max(100, 'Too Long!').optional(),
-    email: Yup.string().email('Invalid email').max(255).required('Required'),
+    email: Yup.string()
+      .email('Invalid email')
+      .max(255)
+      .required('Required')
+      .test('domain', 'Invalid email domain. Please use your @honeycombsoft.com email address', function(value) {
+        if (!value) return true; // Let required() handle empty values
+        const domain = value.split('@')[1];
+        return domain && domain.toLowerCase() === 'honeycombsoft.com';
+      }),
     tenantId: Yup.string().when(['roleIds', '$isSuperAdmin'], {
       is: (roleIds: string[], isContextSuperAdmin: boolean) => {
         const superAdminRole = allRoles?.find((r) => r.name === ROLES.SUPER_ADMIN);


### PR DESCRIPTION
## Summary

- Add email domain validation to restrict user emails to honeycombsoft.com domain only
- Frontend validation using Yup schema with custom test in UserForm.tsx
- Backend validation using class-validator @Matches decorator in CreateUserDto and UpdateUserDto
- Case-insensitive domain matching for honeycombsoft.com
- Consistent error messaging across frontend and backend
- Updated API documentation examples to reflect new domain requirement

## Test plan

- [x] Test frontend validation with invalid domains (should show error message)
- [x] Test frontend validation with valid honeycombsoft.com emails (should pass)
- [x] Test backend validation in CreateUserDto with invalid domains (should reject)
- [x] Test backend validation in UpdateUserDto with invalid domains (should reject)
- [x] Verify API documentation examples are updated
- [x] Ensure existing functionality remains unaffected