### PR TITLE
IA-67: add validation to user email - only honeycombsoft.com domain should be accepted

### DIFF
--- a/api/src/application/common/validators/email-domain.validator.ts
+++ b/api/src/application/common/validators/email-domain.validator.ts
@@ -1,0 +1,33 @@
+import {
+    registerDecorator,
+    ValidationOptions,
+    ValidatorConstraint,
+    ValidatorConstraintInterface,
+    ValidationArguments,
+} from 'class-validator';
+
+@ValidatorConstraint({ async: false })
+export class IsHoneycombEmailConstraint implements ValidatorConstraintInterface {
+    validate(email: string, args: ValidationArguments) {
+        if (!email) return true; // Let @IsEmail() and @IsNotEmpty() handle empty values
+
+        const domain = email.split('@')[1];
+        return domain && domain.toLowerCase() === 'honeycombsoft.com';
+    }
+
+    defaultMessage(args: ValidationArguments) {
+        return 'Invalid email domain. Please use your @honeycombsoft.com email address';
+    }
+}
+
+export function IsHoneycombEmail(validationOptions?: ValidationOptions) {
+    return function (object: object, propertyName: string) {
+        registerDecorator({
+            target: object.constructor,
+            propertyName: propertyName,
+            options: validationOptions,
+            constraints: [],
+            validator: IsHoneycombEmailConstraint,
+        });
+    };
+}

--- a/api/src/application/users/dto/create-user.dto.ts
+++ b/api/src/application/users/dto/create-user.dto.ts
@@ -9,15 +9,17 @@ import {
     ArrayMinSize,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsHoneycombEmail } from '../../common/validators/email-domain.validator';
 
 export class CreateUserDto {
     @ApiProperty({
         description: 'Email address of the user',
-        example: 'user@example.com',
+        example: 'user@honeycombsoft.com',
         maxLength: 255,
     })
     @IsNotEmpty()
     @IsEmail()
+    @IsHoneycombEmail()
     @MaxLength(255)
     email: string;
 

--- a/api/src/application/users/dto/update-user.dto.ts
+++ b/api/src/application/users/dto/update-user.dto.ts
@@ -8,16 +8,18 @@ import {
     IsNotEmpty,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsHoneycombEmail } from '../../common/validators/email-domain.validator';
 
 export class UpdateUserDto {
     @ApiProperty({
         description: 'Email address of the user',
-        example: 'updated@example.com',
+        example: 'updated@honeycombsoft.com',
         required: false,
         maxLength: 255,
     })
     @IsOptional()
     @IsEmail()
+    @IsHoneycombEmail()
     @MaxLength(255)
     email?: string;
 

--- a/client/src/modules/users/components/UserForm.tsx
+++ b/client/src/modules/users/components/UserForm.tsx
@@ -56,7 +56,15 @@ const generateUserSchema = (allRoles: Role[]) =>
   Yup.object().shape({
     firstName: Yup.string().max(100, 'Too Long!').optional(),
     lastName: Yup.string().max(100, 'Too Long!').optional(),
-    email: Yup.string().email('Invalid email').max(255).required('Required'),
+    email: Yup.string()
+      .email('Invalid email')
+      .max(255)
+      .required('Required')
+      .test('domain', 'Invalid email domain. Please use your @honeycombsoft.com email address', function(value) {
+        if (!value) return true; // Let required() handle empty values
+        const domain = value.split('@')[1];
+        return domain && domain.toLowerCase() === 'honeycombsoft.com';
+      }),
     tenantId: Yup.string().when(['roleIds', '$isSuperAdmin'], {
       is: (roleIds: string[], isContextSuperAdmin: boolean) => {
         const superAdminRole = allRoles?.find((r) => r.name === ROLES.SUPER_ADMIN);


### PR DESCRIPTION
## Summary
- Added custom email domain validator for NestJS backend using class-validator
- Updated user DTOs to enforce honeycombsoft.com domain validation
- Implemented frontend Yup validation for consistent user experience
- Case-insensitive domain matching with clear error messaging

## Changes Made
- **Backend**: Created `IsHoneycombEmail` custom validator decorator
- **Backend**: Updated `CreateUserDto` and `UpdateUserDto` with domain validation
- **Frontend**: Enhanced Yup schema in `UserForm.tsx` with domain check
- **Validation**: Both layers now reject non-honeycombsoft.com email addresses

## Test plan
- [x] Linting passes on both API and client
- [x] Custom validator properly validates honeycombsoft.com domain
- [x] Frontend shows appropriate error message for invalid domains
- [x] Case-insensitive validation works correctly
- [ ] Manual testing of user creation/update flows
- [ ] Verify existing functionality remains intact