### PR TITLE
IA-68: Add email validation - accept only Gmail and Honeycombsoft domains

### DIFF
--- a/client/src/modules/users/components/UserForm.tsx
+++ b/client/src/modules/users/components/UserForm.tsx
@@ -56,7 +56,15 @@ const generateUserSchema = (allRoles: Role[]) =>
   Yup.object().shape({
     firstName: Yup.string().max(100, 'Too Long!').optional(),
     lastName: Yup.string().max(100, 'Too Long!').optional(),
-    email: Yup.string().email('Invalid email').max(255).required('Required'),
+    email: Yup.string()
+      .email('Invalid email')
+      .max(255)
+      .required('Required')
+      .test('domain', 'Invalid email domain. Please use @gmail.com or @honeycombsoft.com email address', function(value) {
+        if (!value) return true; // Let required() handle empty values
+        const domain = value.split('@')[1];
+        return domain && ['gmail.com', 'honeycombsoft.com'].includes(domain.toLowerCase());
+      }),
     tenantId: Yup.string().when(['roleIds', '$isSuperAdmin'], {
       is: (roleIds: string[], isContextSuperAdmin: boolean) => {
         const superAdminRole = allRoles?.find((r) => r.name === ROLES.SUPER_ADMIN);


### PR DESCRIPTION
## Summary

- Add Gmail and Honeycombsoft domain validation to user email field in UserForm component
- Case-insensitive domain matching for both @gmail.com and @honeycombsoft.com
- Custom error message: 'Invalid email domain. Please use @gmail.com or @honeycombsoft.com email address'
- Applies to both user creation and updates

## Test plan

- [ ] Test user creation with @gmail.com email - should succeed
- [ ] Test user creation with @honeycombsoft.com email - should succeed  
- [ ] Test user creation with @GMAIL.COM email (uppercase) - should succeed
- [ ] Test user creation with @yahoo.com email - should show validation error
- [ ] Test user update with valid domain - should succeed
- [ ] Test user update with invalid domain - should show validation error
- [ ] Verify existing users with non-Gmail/non-Honeycombsoft emails are not affected