### PR TITLE
IA-69: Add Middle name field to user form

### DIFF
--- a/api/src/application/users/dto/create-user.dto.ts
+++ b/api/src/application/users/dto/create-user.dto.ts
@@ -55,6 +55,17 @@ export class CreateUserDto {
     lastName?: string;
 
     @ApiProperty({
+        description: 'Middle name of the user',
+        example: 'William',
+        required: false,
+        maxLength: 50,
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(50)
+    middleName?: string;
+
+    @ApiProperty({
         description: 'List of role IDs to assign to the user',
         example: ['123e4567-e89b-12d3-a456-426614174000'],
         type: [String],

--- a/api/src/application/users/dto/update-user.dto.ts
+++ b/api/src/application/users/dto/update-user.dto.ts
@@ -55,6 +55,17 @@ export class UpdateUserDto {
     lastName?: string;
 
     @ApiProperty({
+        description: 'Middle name of the user',
+        example: 'William',
+        required: false,
+        maxLength: 50,
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(50)
+    middleName?: string;
+
+    @ApiProperty({
         description: 'List of role IDs to assign to the user',
         example: ['123e4567-e89b-12d3-a456-426614174000'],
         type: [String],

--- a/api/src/domain/entities/user.entity.ts
+++ b/api/src/domain/entities/user.entity.ts
@@ -29,6 +29,9 @@ export class User {
     @Column({ length: 100, nullable: true })
     lastName?: string;
 
+    @Column({ length: 50, nullable: true })
+    middleName?: string;
+
     @Column({ default: true })
     isActive: boolean;
 

--- a/api/src/infrastructure/persistence/migrations/1758391425794-AddMiddleNameToUser.ts
+++ b/api/src/infrastructure/persistence/migrations/1758391425794-AddMiddleNameToUser.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMiddleNameToUser1758391425794 implements MigrationInterface {
+    name = 'AddMiddleNameToUser1758391425794';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "users" ADD "middleName" character varying(50)`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "middleName"`);
+    }
+}

--- a/client/src/modules/users/components/UserForm.tsx
+++ b/client/src/modules/users/components/UserForm.tsx
@@ -47,6 +47,7 @@ type UserFormProps = {
 type UserFormValues = {
   firstName: string;
   lastName: string;
+  middleName: string;
   email: string;
   tenantId?: string;
   roleIds: string[];
@@ -56,6 +57,7 @@ const generateUserSchema = (allRoles: Role[]) =>
   Yup.object().shape({
     firstName: Yup.string().max(100, 'Too Long!').optional(),
     lastName: Yup.string().max(100, 'Too Long!').optional(),
+    middleName: Yup.string().max(50, 'Too Long!').optional(),
     email: Yup.string()
       .email('Invalid email')
       .max(255)
@@ -159,6 +161,7 @@ const UserForm: React.FC<UserFormProps> = ({ user, onClose }) => {
     (): UserFormValues => ({
       firstName: user?.firstName ?? '',
       lastName: user?.lastName ?? '',
+      middleName: user?.middleName ?? '',
       email: user?.email ?? '',
       tenantId: user?.tenant?.id ?? undefined,
       roleIds: user?.roles?.map((r) => r.id) ?? [],
@@ -172,6 +175,7 @@ const UserForm: React.FC<UserFormProps> = ({ user, onClose }) => {
         email: values.email,
         firstName: values.firstName || undefined,
         lastName: values.lastName || undefined,
+        middleName: values.middleName || undefined,
         roleIds: values.roleIds,
       };
 
@@ -189,6 +193,7 @@ const UserForm: React.FC<UserFormProps> = ({ user, onClose }) => {
           email: values.email,
           firstName: values.firstName || undefined,
           lastName: values.lastName || undefined,
+          middleName: values.middleName || undefined,
           roleIds: values.roleIds,
           tenantId: values.tenantId,
         };
@@ -199,6 +204,7 @@ const UserForm: React.FC<UserFormProps> = ({ user, onClose }) => {
           email: values.email,
           firstName: values.firstName || undefined,
           lastName: values.lastName || undefined,
+          middleName: values.middleName || undefined,
           roleIds: values.roleIds,
         };
 
@@ -234,6 +240,14 @@ const UserForm: React.FC<UserFormProps> = ({ user, onClose }) => {
                 fullWidth
                 error={touched.firstName && !!errors.firstName}
                 helperText={touched.firstName && errors.firstName}
+              />
+              <Field
+                as={TextField}
+                name="middleName"
+                label="Middle Name (Optional)"
+                fullWidth
+                error={touched.middleName && !!errors.middleName}
+                helperText={touched.middleName && errors.middleName}
               />
               <Field
                 as={TextField}

--- a/client/src/modules/users/types/user.ts
+++ b/client/src/modules/users/types/user.ts
@@ -11,6 +11,7 @@ export type User = {
   subId?: string;
   firstName?: string;
   lastName?: string;
+  middleName?: string;
   tenant: {
     id: string;
     name: string;

--- a/client/src/modules/users/userMutations.ts
+++ b/client/src/modules/users/userMutations.ts
@@ -7,6 +7,7 @@ export type CreateUserInput = {
   subId?: string;
   firstName?: string;
   lastName?: string;
+  middleName?: string;
 };
 
 export type CreateUserSuperAdminInput = CreateUserInput & {
@@ -19,6 +20,7 @@ export type UpdateUserInput = {
   subId?: string;
   firstName?: string;
   lastName?: string;
+  middleName?: string;
 };
 
 export type UpdateUserPayload = {


### PR DESCRIPTION
## Summary

- Added optional middle name field to user management system
- Field positioned between first and last name in user form
- Supports up to 50 characters per user requirements
- Backend: Added middleName column to User entity and updated DTOs
- Frontend: Added middleName to form with validation and proper handling
- Database: Created migration for new column

## Changes Made

### Backend
- Updated User entity to include middleName column (50 chars, nullable)
- Modified CreateUserDto and UpdateUserDto with validation decorators
- Created database migration for schema change

### Frontend
- Added middleName to User type definition
- Updated CreateUserInput and UpdateUserInput types
- Added middleName field to UserForm between firstName and lastName
- Implemented proper form validation with Yup schema
- Integrated middleName handling in create/update operations

## Test Plan

- [x] Backend linting passes
- [x] Frontend linting passes
- [x] Tests pass (no existing tests affected)
- [ ] Manual testing: Create user with middle name
- [ ] Manual testing: Update user middle name
- [ ] Manual testing: Verify form validation (50 char limit)
- [ ] Manual testing: Verify optional field behavior