### PR TITLE
IA-70: Fix missing middleName property in user creation

### DIFF
--- a/api/src/api/main.ts
+++ b/api/src/api/main.ts
@@ -140,6 +140,7 @@ async function createDefaultTenants(app: INestApplication, logger: Logger): Prom
                 {
                     firstName: item.adminFirstName,
                     lastName: item.adminLastName,
+                    middleName: '',
                     email: item.adminEmail,
                     roleIds: [adminRole!.id, userRole!.id],
                 },
@@ -177,6 +178,7 @@ async function createDefaultSuperAdmin(app: INestApplication, logger: Logger): P
         const superAdminDto = new CreateUserBySuperAdminDto();
 
         superAdminDto.email = superAdminEmail;
+        superAdminDto.middleName = '';
         superAdminDto.roleIds = [superAdminRole!.id];
 
         await userCommands.createUserBySuperAdmin(superAdminDto);


### PR DESCRIPTION
## Summary

Fixed TypeScript compilation error where objects were being created without the required 'middleName' property when the CreateUserDto type expects it.

## Changes Made

- ✅ Added required `middleName` property to admin user creation during tenant initialization in `main.ts:143`
- ✅ Added required `middleName` property to super admin user creation in `main.ts:181`
- ✅ Both instances now provide an empty string as the default middleName value

## Test plan

- [x] Verified the fix addresses the specific TypeScript compilation error mentioned in the task
- [x] Code follows existing patterns in the codebase 
- [x] Changes are minimal and focused on the specific issue

## Root Cause

The middleName field was recently added as a required property to the CreateUserDto class, but the initialization code in main.ts was not updated to include this new required field when creating admin and super admin users during application bootstrap.