### PR TITLE
IA-78: Fix Yup validation context reference error

### DIFF
--- a/client/src/modules/users/components/UserForm.tsx
+++ b/client/src/modules/users/components/UserForm.tsx
@@ -67,15 +67,15 @@ const generateUserSchema = (allRoles: Role[]) =>
         const domain = value.split('@')[1];
         return domain && ['gmail.com', 'honeycombsoft.com'].includes(domain.toLowerCase());
       }),
-    tenantId: Yup.string().when(['roleIds', '$isSuperAdmin'], {
-      is: (roleIds: string[], isContextSuperAdmin: boolean) => {
-        const superAdminRole = allRoles?.find((r) => r.name === ROLES.SUPER_ADMIN);
-        const isSuperAdminRoleSelected = roleIds.includes(superAdminRole?.id ?? '');
+    tenantId: Yup.string().when(['roleIds'], function (roleIds: string[]) {
+      const superAdminRole = allRoles?.find((r) => r.name === ROLES.SUPER_ADMIN);
+      const isSuperAdminRoleSelected = roleIds.includes(superAdminRole?.id ?? '');
+      const isContextSuperAdmin = this.options.context?.isSuperAdmin;
 
-        return isContextSuperAdmin && !isSuperAdminRoleSelected;
-      },
-      then: (schema) => schema.required('Tenant is required unless Super Admin role is selected'),
-      otherwise: (schema) => schema.optional(),
+      if (isContextSuperAdmin && !isSuperAdminRoleSelected) {
+        return this.required('Tenant is required unless Super Admin role is selected');
+      }
+      return this.optional();
     }),
     roleIds: Yup.array()
       .of(Yup.string().required())


### PR DESCRIPTION
## Summary
- Fixed ReferenceError: Cannot access '$' before initialization in UserForm component
- Resolved incorrect Yup validation context reference pattern

## Changes
- Replaced invalid `'$isSuperAdmin'` context reference with proper `this.options.context.isSuperAdmin` access
- Updated Yup.when() method from object syntax to function syntax for better context handling
- Maintained the same validation logic ensuring tenant requirement based on super admin role selection

## Technical Details
The issue was caused by attempting to use `'$isSuperAdmin'` in the Yup `when()` method's dependencies array. This syntax is invalid - context variables should be accessed through `this.options.context` within the validation function.

## Test Plan
- Validated that linting passes with no errors
- Confirmed the validation logic remains functionally identical
- Verified no similar patterns exist in the codebase