### PR TITLE
IA-88: Add currency and days overdue columns to invoices

### DIFF
--- a/api/src/application/invoices/dto/invoice.dto.ts
+++ b/api/src/application/invoices/dto/invoice.dto.ts
@@ -105,6 +105,18 @@ export class InvoiceDto {
     totalAmount!: number;
 
     @ApiProperty({
+        description: 'Currency of the invoice',
+        example: 'USD',
+    })
+    currency!: string;
+
+    @ApiProperty({
+        description: 'Number of days the invoice is overdue (0 or negative if not overdue)',
+        example: 5,
+    })
+    daysOverdue!: number;
+
+    @ApiProperty({
         description: 'Status of the invoice',
         example: 'UNPAID',
         enum: ['PAID', 'UNPAID', 'OVERDUE'],

--- a/api/src/application/invoices/invoice.mapper.ts
+++ b/api/src/application/invoices/invoice.mapper.ts
@@ -26,6 +26,10 @@ export class InvoiceMapper {
         dto.taxRate = entity.taxRate;
         dto.taxAmount = entity.taxAmount;
         dto.totalAmount = entity.totalAmount;
+        dto.currency = entity.currency;
+        dto.daysOverdue = this.calculateDaysOverdue(entity.dueDate);
+        dto.status = entity.status;
+        dto.terms = entity.terms;
         dto.tenantId = entity.tenantId;
         dto.items = entity.items ? entity.items.map((item) => this.toItemDto(item)) : [];
 
@@ -50,6 +54,14 @@ export class InvoiceMapper {
         response.totalPages = Math.ceil(total / limit);
 
         return response;
+    }
+
+    private calculateDaysOverdue(dueDate: string): number {
+        const today = new Date();
+        const due = new Date(dueDate);
+        const timeDiff = today.getTime() - due.getTime();
+        const daysDiff = Math.floor(timeDiff / (1000 * 3600 * 24));
+        return Math.max(0, daysDiff);
     }
 
     private toItemDto(entity: InvoiceItem): InvoiceItemDto {

--- a/api/src/domain/entities/invoice.entity.ts
+++ b/api/src/domain/entities/invoice.entity.ts
@@ -55,6 +55,9 @@ export class Invoice {
     @Column({ type: 'decimal', precision: 12, scale: 2 })
     totalAmount!: number;
 
+    @Column({ length: 3, default: 'USD' })
+    currency!: string;
+
     @Column({ length: 50, default: 'UNPAID' })
     status!: string;
 

--- a/api/src/infrastructure/persistence/migrations/1758616876009-AddCurrencyToInvoices.ts
+++ b/api/src/infrastructure/persistence/migrations/1758616876009-AddCurrencyToInvoices.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCurrencyToInvoices1758616876009 implements MigrationInterface {
+    name = 'AddCurrencyToInvoices1758616876009';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "invoices" ADD "currency" character varying(3) NOT NULL DEFAULT 'USD'`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "invoices" DROP COLUMN "currency"`);
+    }
+}

--- a/client/src/modules/invoices/components/InvoiceTable.tsx
+++ b/client/src/modules/invoices/components/InvoiceTable.tsx
@@ -112,10 +112,10 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({
   };
 
   // Format currency
-  const formatCurrency = (amount: number): string => {
+  const formatCurrency = (amount: number, currency: string = 'USD'): string => {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
-      currency: 'USD',
+      currency: currency,
     }).format(amount);
   };
 
@@ -126,6 +126,33 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({
     } catch {
       return dateString;
     }
+  };
+
+  // Format days overdue
+  const formatDaysOverdue = (daysOverdue: number) => {
+    if (daysOverdue === 0) {
+      return (
+        <Typography color="text.secondary">
+          –
+        </Typography>
+      );
+    }
+
+    return (
+      <Typography
+        color="error"
+        fontWeight="medium"
+        sx={{
+          backgroundColor: theme => theme.palette.error.light + '20',
+          px: 1,
+          py: 0.5,
+          borderRadius: 1,
+          display: 'inline-block',
+        }}
+      >
+        {daysOverdue} days
+      </Typography>
+    );
   };
 
   // Calculate and display the status of an invoice
@@ -173,6 +200,8 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({
               <TableCell>Issue Date</TableCell>
               <TableCell>Due Date</TableCell>
               <TableCell>Total Amount</TableCell>
+              <TableCell>Currency</TableCell>
+              <TableCell>Days Overdue</TableCell>
               <TableCell>Status</TableCell>
               <TableCell align="right">Actions</TableCell>
             </TableRow>
@@ -195,7 +224,7 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({
               // Loading skeletons
               Array.from(new Array(5)).map((_, index) => (
                 <TableRow key={`skeleton-${index}`}>
-                  {Array.from(new Array(8)).map((_, cellIndex) => (
+                  {Array.from(new Array(10)).map((_, cellIndex) => (
                     <TableCell key={`cell-${index}-${cellIndex}`}>
                       <Skeleton animation="wave" />
                     </TableCell>
@@ -223,7 +252,9 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({
                   <TableCell>{invoice.customerName}</TableCell>
                   <TableCell>{formatDate(invoice.issueDate)}</TableCell>
                   <TableCell>{formatDate(invoice.dueDate)}</TableCell>
-                  <TableCell>{formatCurrency(invoice.totalAmount)}</TableCell>
+                  <TableCell>{formatCurrency(invoice.totalAmount, invoice.currency)}</TableCell>
+                  <TableCell>{invoice.currency}</TableCell>
+                  <TableCell>{formatDaysOverdue(invoice.daysOverdue)}</TableCell>
                   <TableCell>{getInvoiceStatus(invoice)}</TableCell>
                   <TableCell align="right">
                     <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
@@ -254,7 +285,7 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({
               ))
             ) : (
               <TableRow>
-                <TableCell colSpan={8} align="center" sx={{ py: 3 }}>
+                <TableCell colSpan={10} align="center" sx={{ py: 3 }}>
                   No invoices found.
                 </TableCell>
               </TableRow>
@@ -279,7 +310,7 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({
                     {formatCurrency(calculatePageTotal())}
                   </Typography>
                 </TableCell>
-                <TableCell colSpan={2}></TableCell>
+                <TableCell colSpan={4}></TableCell>
               </TableRow>
             )}
           </TableBody>

--- a/client/src/modules/invoices/types/invoice.ts
+++ b/client/src/modules/invoices/types/invoice.ts
@@ -25,6 +25,8 @@ export interface Invoice {
   taxRate: number;
   taxAmount: number;
   totalAmount: number;
+  currency: string;
+  daysOverdue: number;
   status: 'PAID' | 'UNPAID' | 'OVERDUE';
   terms?: string;
   items: InvoiceItem[];


### PR DESCRIPTION
## Summary

- Added currency field to Invoice entity with USD default value
- Created database migration to add currency column
- Added daysOverdue calculation to show number of days an invoice is overdue
- Updated frontend table to display Currency and Days Overdue columns
- Implemented highlighting for overdue invoices (red background) and dash for non-overdue

## Changes Made

### Backend
- Added `currency` field to Invoice entity with 3-character limit and USD default
- Created migration `AddCurrencyToInvoices1758616876009` 
- Updated `InvoiceDto` to include `currency` and `daysOverdue` fields
- Added `calculateDaysOverdue()` method to invoice mapper for date calculations

### Frontend
- Updated Invoice TypeScript interface to include new fields
- Added Currency and Days Overdue columns to InvoiceTable component
- Enhanced currency formatting to use invoice-specific currency
- Added highlighting for overdue invoices with red background
- Shows dash (–) for invoices that are not overdue

## Test Plan

- [ ] Verify new columns appear in invoice table
- [ ] Check currency formatting displays correctly with invoice currency
- [ ] Confirm overdue invoices show days count with red highlighting
- [ ] Verify non-overdue invoices show dash (–)
- [ ] Test database migration runs successfully
- [ ] Ensure existing invoice data displays properly