### PR TITLE
IA-95: Change blue button color to hot pink

### DIFF
--- a/client/src/themes/darkTheme.ts
+++ b/client/src/themes/darkTheme.ts
@@ -5,9 +5,9 @@ export const darkTheme = createTheme({
   palette: {
     mode: 'dark',
     primary: {
-      main: '#90CAF9',
-      light: '#B3E5FC',
-      dark: '#42A5F5',
+      main: '#FF69B4',
+      light: '#FF94D0',
+      dark: '#FF1493',
       contrastText: '#000000',
     },
     secondary: {
@@ -80,18 +80,18 @@ export const darkTheme = createTheme({
           },
         },
         contained: {
-          backgroundColor: '#90CAF9',
+          backgroundColor: '#FF69B4',
           color: '#000000',
           '&:hover': {
-            backgroundColor: '#42A5F5',
+            backgroundColor: '#FF1493',
           },
         },
         outlined: {
           borderColor: 'rgba(255, 255, 255, 0.23)',
-          color: '#90CAF9',
+          color: '#FF69B4',
           '&:hover': {
-            borderColor: '#90CAF9',
-            backgroundColor: 'rgba(144, 202, 249, 0.08)',
+            borderColor: '#FF69B4',
+            backgroundColor: 'rgba(255, 105, 180, 0.08)',
           },
         },
       },
@@ -100,7 +100,7 @@ export const darkTheme = createTheme({
       styleOverrides: {
         root: {
           '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-            borderColor: '#90CAF9',
+            borderColor: '#FF69B4',
           },
           '&:hover .MuiOutlinedInput-notchedOutline': {
             borderColor: 'rgba(255, 255, 255, 0.23)',
@@ -112,10 +112,10 @@ export const darkTheme = createTheme({
       styleOverrides: {
         root: {
           '&.Mui-selected': {
-            backgroundColor: 'rgba(144, 202, 249, 0.16)',
+            backgroundColor: 'rgba(255, 105, 180, 0.16)',
           },
           '&.Mui-selected:hover': {
-            backgroundColor: 'rgba(144, 202, 249, 0.24)',
+            backgroundColor: 'rgba(255, 105, 180, 0.24)',
           },
           '&:hover': {
             backgroundColor: 'rgba(255, 255, 255, 0.08)',
@@ -174,7 +174,7 @@ export const darkTheme = createTheme({
               borderColor: 'rgba(255, 255, 255, 0.4)',
             },
             '&.Mui-focused fieldset': {
-              borderColor: '#90CAF9',
+              borderColor: '#FF69B4',
             },
           },
         },


### PR DESCRIPTION
## Summary

- Changed primary color palette from blue (#90CAF9) to hot pink (#FF69B4)
- Updated both contained and outlined button variants to use hot pink
- Applied hot pink color to all primary UI elements including buttons, text fields, selects, and menu items

## Changes Made

1. **Palette Colors**: Updated `palette.primary` with hot pink variants:
   - main: #FF69B4 (hot pink)
   - light: #FF94D0 (lighter pink)
   - dark: #FF1493 (deep pink for hover states)

2. **Button Components**:
   - Contained buttons: Hot pink background with deep pink hover
   - Outlined buttons: Hot pink border and text with pink hover background

3. **Form Elements**:
   - Text fields: Hot pink focus border
   - Select inputs: Hot pink focus border
   - Menu items: Hot pink selection background

## Test Plan

- [ ] Verify all contained buttons display with hot pink background
- [ ] Verify all outlined buttons display with hot pink border and text
- [ ] Test button hover states show proper deep pink color
- [ ] Check text field focus states show hot pink border
- [ ] Verify select dropdowns show hot pink focus border
- [ ] Test menu item selection shows hot pink background
- [ ] Ensure sufficient contrast for readability in dark mode