### PR TITLE
IA-97: Update blue button color to pink

### DIFF
--- a/client/src/themes/darkTheme.ts
+++ b/client/src/themes/darkTheme.ts
@@ -5,9 +5,9 @@ export const darkTheme = createTheme({
   palette: {
     mode: 'dark',
     primary: {
-      main: '#90CAF9',
-      light: '#B3E5FC',
-      dark: '#42A5F5',
+      main: '#FFB6C1',
+      light: '#FFD4DC',
+      dark: '#FF91A4',
       contrastText: '#000000',
     },
     secondary: {
@@ -80,18 +80,18 @@ export const darkTheme = createTheme({
           },
         },
         contained: {
-          backgroundColor: '#90CAF9',
+          backgroundColor: '#FFB6C1',
           color: '#000000',
           '&:hover': {
-            backgroundColor: '#42A5F5',
+            backgroundColor: '#FF91A4',
           },
         },
         outlined: {
           borderColor: 'rgba(255, 255, 255, 0.23)',
-          color: '#90CAF9',
+          color: '#FFB6C1',
           '&:hover': {
-            borderColor: '#90CAF9',
-            backgroundColor: 'rgba(144, 202, 249, 0.08)',
+            borderColor: '#FFB6C1',
+            backgroundColor: 'rgba(255, 182, 193, 0.08)',
           },
         },
       },
@@ -100,7 +100,7 @@ export const darkTheme = createTheme({
       styleOverrides: {
         root: {
           '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-            borderColor: '#90CAF9',
+            borderColor: '#FFB6C1',
           },
           '&:hover .MuiOutlinedInput-notchedOutline': {
             borderColor: 'rgba(255, 255, 255, 0.23)',
@@ -112,10 +112,10 @@ export const darkTheme = createTheme({
       styleOverrides: {
         root: {
           '&.Mui-selected': {
-            backgroundColor: 'rgba(144, 202, 249, 0.16)',
+            backgroundColor: 'rgba(255, 182, 193, 0.16)',
           },
           '&.Mui-selected:hover': {
-            backgroundColor: 'rgba(144, 202, 249, 0.24)',
+            backgroundColor: 'rgba(255, 182, 193, 0.24)',
           },
           '&:hover': {
             backgroundColor: 'rgba(255, 255, 255, 0.08)',
@@ -174,7 +174,7 @@ export const darkTheme = createTheme({
               borderColor: 'rgba(255, 255, 255, 0.4)',
             },
             '&.Mui-focused fieldset': {
-              borderColor: '#90CAF9',
+              borderColor: '#FFB6C1',
             },
           },
         },


### PR DESCRIPTION
## Summary
This PR updates the button colors from blue to pastel pink throughout the application by modifying the Material UI theme configuration.

## Changes Made
- Updated primary palette colors from blue (#90CAF9) to pastel pink (#FFB6C1)
- Changed light variant to #FFD4DC and dark variant to #FF91A4
- Modified MuiButton contained and outlined styles to use pastel pink
- Updated focus/selection colors for MuiSelect, MuiMenuItem, and MuiTextField components
- Adjusted rgba opacity values for consistency with the new pastel pink color scheme

## Implementation Details
All changes are centralized in the `client/src/themes/darkTheme.ts` file, ensuring consistency across the application. The pastel pink colors provide a softer appearance while maintaining sufficient contrast on the dark background.

## Testing
- Visual inspection confirms the buttons and interactive elements now display in pastel pink
- No functional changes were made, only color styling updates