### PR TITLE
IA-131: Add Manage account page

### DIFF
--- a/client/src/common/components/CustomUserButton.tsx
+++ b/client/src/common/components/CustomUserButton.tsx
@@ -16,6 +16,7 @@ import {
 import SettingsIcon from '@mui/icons-material/Settings';
 import LogoutIcon from '@mui/icons-material/Logout';
 import { useClerk, useUser } from '@clerk/clerk-react';
+import { useNavigate } from 'react-router-dom';
 
 type CustomUserButtonProps = {
   afterSignOutUrl: string;
@@ -27,6 +28,7 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
   const { signOut } = useClerk();
   const { user } = useUser();
   const theme = useTheme();
+  const navigate = useNavigate();
 
   const handleClick = (): void => {
     setAnchorEl(buttonRef.current);
@@ -45,6 +47,7 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
 
   const handleManageAccount = (): void => {
     handleClose();
+    navigate('/account');
   };
 
   const open = Boolean(anchorEl);

--- a/client/src/modules/account/accountMutations.ts
+++ b/client/src/modules/account/accountMutations.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+import { User } from '../users/types/user';
+
+export type UpdateProfileInput = {
+  firstName?: string;
+  lastName?: string;
+};
+
+export type UpdateProfilePayload = {
+  id: string;
+  data: UpdateProfileInput;
+};
+
+export const updateProfile = (payload: UpdateProfilePayload) =>
+  axios.patch<User>(`/users/${payload.id}`, payload.data);

--- a/client/src/modules/account/accountQueries.ts
+++ b/client/src/modules/account/accountQueries.ts
@@ -1,0 +1,4 @@
+import axios from 'axios';
+import { User } from '../users/types/user';
+
+export const getCurrentUser = (userId: string) => axios.get<User>(`/users/${userId}`);

--- a/client/src/modules/account/accountQueryKeys.ts
+++ b/client/src/modules/account/accountQueryKeys.ts
@@ -1,0 +1,3 @@
+export const ACCOUNT_QUERY_KEYS = {
+  currentUser: (userId: string) => ['account', 'currentUser', userId] as const,
+};

--- a/client/src/modules/account/components/AccountPage.tsx
+++ b/client/src/modules/account/components/AccountPage.tsx
@@ -1,0 +1,230 @@
+import React, { useEffect } from 'react';
+import { useSnackbar } from 'notistack';
+import {
+  Box,
+  Card,
+  CardContent,
+  CardHeader,
+  Typography,
+  TextField,
+  Button,
+  CircularProgress,
+  Stack,
+  Divider,
+  useTheme,
+} from '@mui/material';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useUser } from '@clerk/clerk-react';
+import { Formik, Form, Field } from 'formik';
+import * as Yup from 'yup';
+import { getCurrentUser } from '../accountQueries';
+import { updateProfile, UpdateProfilePayload } from '../accountMutations';
+import { ACCOUNT_QUERY_KEYS } from '../accountQueryKeys';
+import { CACHE_TIMES } from '../../../common/constants/cacheTimes';
+
+const profileValidationSchema = Yup.object({
+  firstName: Yup.string().max(50, 'First name must be at most 50 characters'),
+  lastName: Yup.string().max(50, 'Last name must be at most 50 characters'),
+});
+
+const AccountPage: React.FC = () => {
+  const theme = useTheme();
+  const { enqueueSnackbar } = useSnackbar();
+  const queryClient = useQueryClient();
+  const { user: clerkUser } = useUser();
+
+  const userId = clerkUser?.publicMetadata?.userId as string | undefined;
+
+  const {
+    data: userData,
+    isLoading,
+    error: queryError,
+  } = useQuery({
+    queryKey: ACCOUNT_QUERY_KEYS.currentUser(userId || ''),
+    queryFn: () => getCurrentUser(userId!),
+    enabled: !!userId,
+    staleTime: CACHE_TIMES.DEFAULT,
+  });
+
+  const user = userData?.data;
+
+  useEffect(() => {
+    if (queryError) {
+      enqueueSnackbar(queryError?.message || 'Failed to load user data', {
+        variant: 'error',
+      });
+    }
+  }, [queryError, enqueueSnackbar]);
+
+  const updateProfileMutation = useMutation({
+    mutationFn: updateProfile,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ACCOUNT_QUERY_KEYS.currentUser(userId || '') });
+      enqueueSnackbar('Profile updated successfully', { variant: 'success' });
+    },
+    onError: (error: Error) => {
+      enqueueSnackbar(error.message || 'Failed to update profile', { variant: 'error' });
+    },
+  });
+
+  const handlePasswordChange = () => {
+    window.open('https://accounts.clerk.dev/user', '_blank');
+    enqueueSnackbar('Opening Clerk account settings in a new tab', { variant: 'info' });
+  };
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!user) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6" color="error">
+          Unable to load user data
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ backgroundColor: theme.palette.background.default, minHeight: '100vh', p: 2 }}>
+      <Card
+        sx={{
+          maxWidth: 800,
+          mx: 'auto',
+          backgroundColor: theme.palette.background.paper,
+          color: theme.palette.text.primary,
+        }}>
+        <CardHeader
+          title={
+            <Typography variant="h5" component="h1" sx={{ fontWeight: 'bold' }}>
+              Manage Account
+            </Typography>
+          }
+        />
+        <CardContent>
+          <Stack spacing={4}>
+            <Box>
+              <Typography variant="h6" sx={{ mb: 2, fontWeight: 'medium' }}>
+                Profile Information
+              </Typography>
+              <Formik
+                initialValues={{
+                  firstName: user.firstName || '',
+                  lastName: user.lastName || '',
+                }}
+                validationSchema={profileValidationSchema}
+                onSubmit={(values) => {
+                  const payload: UpdateProfilePayload = {
+                    id: user.id,
+                    data: {
+                      firstName: values.firstName || undefined,
+                      lastName: values.lastName || undefined,
+                    },
+                  };
+                  updateProfileMutation.mutate(payload);
+                }}
+                enableReinitialize>
+                {({ errors, touched, isSubmitting }) => (
+                  <Form>
+                    <Stack spacing={2}>
+                      <Field name="firstName">
+                        {({ field }: { field: { name: string; value: string; onChange: (e: React.ChangeEvent) => void; onBlur: (e: React.FocusEvent) => void } }) => (
+                          <TextField
+                            {...field}
+                            label="First Name"
+                            fullWidth
+                            error={touched.firstName && Boolean(errors.firstName)}
+                            helperText={touched.firstName && errors.firstName}
+                          />
+                        )}
+                      </Field>
+                      <Field name="lastName">
+                        {({ field }: { field: { name: string; value: string; onChange: (e: React.ChangeEvent) => void; onBlur: (e: React.FocusEvent) => void } }) => (
+                          <TextField
+                            {...field}
+                            label="Last Name"
+                            fullWidth
+                            error={touched.lastName && Boolean(errors.lastName)}
+                            helperText={touched.lastName && errors.lastName}
+                          />
+                        )}
+                      </Field>
+                      <TextField
+                        label="Email"
+                        value={user.email}
+                        fullWidth
+                        disabled
+                        helperText="Email cannot be changed"
+                      />
+                      <Box>
+                        <Button
+                          type="submit"
+                          variant="contained"
+                          disabled={isSubmitting || updateProfileMutation.isPending}
+                          sx={{ minWidth: 120 }}>
+                          {updateProfileMutation.isPending ? 'Saving...' : 'Save Changes'}
+                        </Button>
+                      </Box>
+                    </Stack>
+                  </Form>
+                )}
+              </Formik>
+            </Box>
+
+            <Divider />
+
+            <Box>
+              <Typography variant="h6" sx={{ mb: 2, fontWeight: 'medium' }}>
+                Account Details
+              </Typography>
+              <Stack spacing={2}>
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    Tenant
+                  </Typography>
+                  <Typography variant="body1">{user.tenant.name}</Typography>
+                </Box>
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    Roles
+                  </Typography>
+                  <Typography variant="body1">
+                    {user.roles.map((role) => role.name).join(', ')}
+                  </Typography>
+                </Box>
+              </Stack>
+            </Box>
+
+            <Divider />
+
+            <Box>
+              <Typography variant="h6" sx={{ mb: 2, fontWeight: 'medium' }}>
+                Security
+              </Typography>
+              <Stack spacing={2}>
+                <Box>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Password
+                  </Typography>
+                  <Button variant="outlined" onClick={handlePasswordChange}>
+                    Change Password
+                  </Button>
+                  <Typography variant="caption" display="block" sx={{ mt: 1, color: 'text.secondary' }}>
+                    Opens Clerk account settings in a new tab
+                  </Typography>
+                </Box>
+              </Stack>
+            </Box>
+          </Stack>
+        </CardContent>
+      </Card>
+    </Box>
+  );
+};
+
+export default AccountPage;

--- a/client/src/routes/AppRoutes.tsx
+++ b/client/src/routes/AppRoutes.tsx
@@ -8,6 +8,7 @@ import ProtectedRoute from '../common/components/ProtectedRoute';
 import { ROLES } from '../common/constants/roles';
 import InvoiceManagementPage from '../modules/invoices/components/InvoiceManagementPage';
 import HomePage from '../modules/home/components/HomePage';
+import AccountPage from '../modules/account/components/AccountPage';
 
 const AppRoutes: React.FC = () => {
   return (
@@ -15,6 +16,7 @@ const AppRoutes: React.FC = () => {
       <Routes>
         <Route element={<MainLayout />}>
           <Route path="/" element={<HomePage />} />
+          <Route path="/account" element={<AccountPage />} />
           <Route element={<ProtectedRoute requiredRoles={[ROLES.SUPER_ADMIN]} />}>
             <Route path="/tenant-management" element={<TenantManagementPage />} />
             <Route path="/invoice-management" element={<InvoiceManagementPage />} />


### PR DESCRIPTION
## Summary

- Created a full-page Manage Account route at `/account` accessible to all authenticated users
- Implemented profile editing form for firstName and lastName fields (email is read-only)
- Integrated password management via Clerk external settings
- Updated the user menu "Manage account" button to navigate to the new page
- Displays user information including tenant and roles

## Implementation Details

**New Account Module:**
- `client/src/modules/account/` - New module following existing architecture patterns
- `AccountPage.tsx` - Main page component with Material UI Card layout
- `accountQueries.ts` - Query functions for fetching current user data
- `accountMutations.ts` - Mutation functions for updating user profile
- `accountQueryKeys.ts` - React Query cache keys

**Changes to Existing Files:**
- `AppRoutes.tsx` - Added `/account` route (no role restrictions)
- `CustomUserButton.tsx` - Updated "Manage account" button to navigate to the new page

**Features:**
- Profile editing with Formik + Yup validation
- Real-time updates using React Query mutations
- Read-only display of email, tenant, and roles
- Password change via Clerk account settings (opens in new tab)
- Consistent Material UI theming and responsive design

## Test Plan

- [ ] Verify `/account` route is accessible for all authenticated users
- [ ] Test profile editing (firstName, lastName) saves successfully
- [ ] Confirm email field is read-only
- [ ] Verify tenant and roles display correctly
- [ ] Test "Manage account" button navigation from user menu
- [ ] Confirm password change button opens Clerk settings
- [ ] Check responsive design on mobile and desktop
- [ ] Verify form validation works correctly
- [ ] Test error handling for API failures