### PR TITLE
IA-431 Resolve issue with export to Excel on invoices page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -192,25 +192,7 @@ export class InvoiceController {
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
         summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
-    })
-    @ApiQuery({
-        name: 'status',
-        required: false,
-        enum: ['PAID', 'UNPAID', 'OVERDUE'],
-        description: 'Filter invoices by status',
+        description: 'Exports all invoices to an Excel file regardless of pagination or filters',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -221,10 +203,9 @@ export class InvoiceController {
     async exportToExcel(
         @Req() request: RequestWithTenant,
         @Res() response: Response,
-        @Query() paginationParams: PaginationParamsDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        const buffer = await this.invoiceService.exportToExcel(tenantId);
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -16,7 +16,7 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    exportToExcel(tenantId: string): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -104,11 +104,8 @@ export class InvoiceService implements IInvoiceService {
         await this.invoiceRepository.remove(id, tenantId);
     }
 
-    async exportToExcel(
-        tenantId: string,
-        paginationParams: PaginationParamsDto,
-    ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+    async exportToExcel(tenantId: string): Promise<Buffer> {
+        const invoices = await this.invoiceRepository.findAllWithoutPagination(tenantId);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -41,6 +41,19 @@ export class InvoiceRepository {
         });
     }
 
+    /**
+     * Retrieves all invoices for a tenant without any pagination or filters.
+     * Used for export operations where the full dataset is required.
+     */
+    async findAllWithoutPagination(tenantId: string): Promise<Invoice[]> {
+        return this.invoiceRepository.find({
+            where: { tenantId },
+            order: {
+                issueDate: 'DESC',
+            },
+        });
+    }
+
     async findById(id: string, tenantId: string): Promise<Invoice | null> {
         return this.invoiceRepository.findOne({
             where: { id, tenantId },

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -262,7 +262,7 @@ const InvoiceManagementPage: React.FC = () => {
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      const blob = await invoiceService.exportInvoices();
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,23 +80,12 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
-   * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * Export all invoices to Excel file.
+   * All invoices are exported regardless of pagination or active filters.
    * @returns Promise<Blob>
    */
-  exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
-    status?: string,
-  ): Promise<Blob> => {
+  exportInvoices: async (): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
-      params: {
-        page,
-        limit,
-        ...(status && { status }),
-      },
       responseType: 'blob',
     });
     return response.data;


### PR DESCRIPTION
Implementation of IA-431

Currently, when a user tries to export invoices, only the invoices visible on a page are exported.
Expected result: all invoices, regardless of pagination and filtering, must be exported

# Implementation Plan

## Conceptual Checklist

- Understand the full data flow: frontend call -> service -> API controller -> backend service -> repository
- Identify all layers that need changes (frontend service, frontend component, backend service, possibly backend controller/repository)
- Respect clean architecture: no business logic in presentation/infrastructure layers
- Maintain existing patterns (DTOs, service interfaces)
- Ensure the export endpoint still returns proper Excel format

## Overview

Fix the invoice export to retrieve ALL invoices instead of only the current page. Changes span both frontend (remove pagination params from export call) and backend (bypass pagination in export logic).

## Assumptions and Rules from CLAUDE.md

- **Clean Architecture (CLAUDE.md):** Dependencies point inward; changes to the interface must propagate correctly.
- **CQRS pattern:** Export is a read/query operation.
- **Assumption:** 'Regardless of filtering' means ignore ALL filters per task description.

## Step-by-Step Implementation

1. **Backend: Add `findAllWithoutPagination` to `InvoiceRepository`**
- New method that queries all invoices for a tenant without `skip`/`take`, optionally ignoring status/archived filters.
- Files: `api/src/application/repositories/invoice.repository.ts`

2. **Backend: Update `IInvoiceService` interface**
- Change `exportToExcel` signature to accept only `tenantId` (remove `PaginationParamsDto`).
- Files: `api/src/application/invoices/interfaces/invoice.service.interface.ts`

3. **Backend: Update `InvoiceService.exportToExcel`**
- Call the new repository method instead of `findAll` with pagination.
- Files: `api/src/application/invoices/invoice.service.ts`

4. **Backend: Update `InvoiceController.exportToExcel`**
- Remove `@Query() paginationParams` from the endpoint; pass only `tenantId`.
- Files: `api/src/api/controllers/invoice.controller.ts`

5. **Frontend: Update `invoiceService.exportInvoices`**
- Remove `page`, `limit`, `status` parameters; call `/invoices/export/excel` without query params.
- Files: `client/src/modules/invoices/services/invoiceService.ts`

6. **Frontend: Update `handleExportToExcel` in `InvoiceManagementPage`**
- Call `invoiceService.exportInvoices()` without arguments.
- Files: `client/src/modules/invoices/components/InvoiceManagementPage.tsx`

7. **Verify:** Run `npm run lint` in both `api/` and `client/` directories.

## Error Handling and Uncertainties

- **Large datasets:** If there are many thousands of invoices, exporting all at once could cause memory issues. Consider streaming or chunked approach if needed, but for now assume dataset is manageable.
- **Filter ambiguity:** Task says 'regardless of filtering' — assumed to mean ignore ALL filters. If the intent is to keep some filters, adjustment is minimal (keep status param optional).