### PR TITLE
IA-434 Resolve issue with export to Excel on invoices page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -192,25 +192,7 @@ export class InvoiceController {
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
         summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
-    })
-    @ApiQuery({
-        name: 'status',
-        required: false,
-        enum: ['PAID', 'UNPAID', 'OVERDUE'],
-        description: 'Filter invoices by status',
+        description: 'Exports all invoices to an Excel file. All records are included regardless of pagination.',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -221,10 +203,9 @@ export class InvoiceController {
     async exportToExcel(
         @Req() request: RequestWithTenant,
         @Res() response: Response,
-        @Query() paginationParams: PaginationParamsDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        const buffer = await this.invoiceService.exportToExcel(tenantId);
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -16,7 +16,7 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    exportToExcel(tenantId: string): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -104,11 +104,10 @@ export class InvoiceService implements IInvoiceService {
         await this.invoiceRepository.remove(id, tenantId);
     }
 
-    async exportToExcel(
-        tenantId: string,
-        paginationParams: PaginationParamsDto,
-    ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+    async exportToExcel(tenantId: string): Promise<Buffer> {
+        // Fetch all non-archived invoices without pagination so the export
+        // always includes every record, regardless of the current page view.
+        const invoices = await this.invoiceRepository.findAllForExport(tenantId);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -41,6 +41,17 @@ export class InvoiceRepository {
         });
     }
 
+    /**
+     * Fetch all non-archived invoices for a tenant without pagination constraints.
+     * Used for full exports so that all records are included regardless of page size.
+     */
+    async findAllForExport(tenantId: string): Promise<Invoice[]> {
+        return this.invoiceRepository.find({
+            where: { tenantId, isArchived: false },
+            order: { issueDate: 'DESC' },
+        });
+    }
+
     async findById(id: string, tenantId: string): Promise<Invoice | null> {
         return this.invoiceRepository.findOne({
             where: { id, tenantId },

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -262,7 +262,8 @@ const InvoiceManagementPage: React.FC = () => {
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      // Export all invoices without pagination or filter constraints
+      const blob = await invoiceService.exportInvoices();
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,23 +80,12 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
-   * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * Export all invoices to an Excel file.
+   * All records are exported regardless of current pagination or filters.
    * @returns Promise<Blob>
    */
-  exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
-    status?: string,
-  ): Promise<Blob> => {
+  exportInvoices: async (): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
-      params: {
-        page,
-        limit,
-        ...(status && { status }),
-      },
       responseType: 'blob',
     });
     return response.data;


### PR DESCRIPTION
Implementation of IA-434

Currently, when a user tries to export invoices, only the invoices visible on a page are exported.
Expected result: all invoices, regardless of pagination and filtering, must be exported

# Implementation Plan

## Conceptual Checklist

- Identify all layers affected (controller, service, repository, frontend service, frontend component)
- Ensure the repository can return all invoices without pagination
- Maintain the existing export endpoint contract while removing pagination constraints
- Follow clean architecture: changes flow inward (API → Application → Domain)
- Preserve status/archived filtering behavior per assumption (exclude archived, ignore status)
- Run linting after changes (`npm run lint:fix`)

## Overview

Remove pagination from the invoice export flow so all invoices are exported. The frontend should stop sending page/limit params for export, and the backend should fetch all matching invoices without skip/take.

## Assumptions and Rules from CLAUDE.md

- Dependencies point inward: API → Application → Domain (project CLAUDE.md)
- Use DTOs for data transfer between layers (project CLAUDE.md)
- No business logic in infrastructure or presentation layers (project CLAUDE.md)
- Run `npm run lint:fix` after changes (project CLAUDE.md linting policy)
- Archived invoices excluded by default (existing codebase convention)

## Step-by-Step Implementation

1. **Add `findAllWithoutPagination` method to `InvoiceRepository`**
- File: `api/src/application/repositories/invoice.repository.ts`
- New method that queries with tenantId, optional status, excludes archived, but NO skip/take
- Returns `Invoice[]` (no count needed)

2. **Update `exportToExcel` in `InvoiceService`**
- File: `api/src/application/invoices/invoice.service.ts`
- Change line 111 to call the new repository method instead of `findAll`
- Remove dependency on `paginationParams` for pagination; optionally keep status param

3. **Update `IInvoiceService` interface**
- File: `api/src/application/invoices/interfaces/invoice.service.interface.ts`
- Update `exportToExcel` signature to not require `PaginationParamsDto` (or make it optional)

4. **Update `exportToExcel` controller endpoint**
- File: `api/src/api/controllers/invoice.controller.ts`
- Remove page/limit query params from the export endpoint (lines 197-208)
- Keep status as optional filter if desired, or remove per task requirement

5. **Update frontend `exportInvoices` service**
- File: `client/src/modules/invoices/services/invoiceService.ts`
- Remove page/limit params from the API call (lines 89-101)

6. **Update frontend `handleExportToExcel` handler**
- File: `client/src/modules/invoices/components/InvoiceManagementPage.tsx`
- Remove page/limit/status args from `exportInvoices()` call (line 265)

7. **Lint both projects**: `cd api && npm run lint` and `cd client && npm run lint`

## Error Handling and Uncertainties

- **Large dataset concern**: Exporting all invoices without pagination could be memory-intensive for very large datasets. Consider if streaming or chunked processing is needed — for now, assume dataset size is manageable.
- **Filter ambiguity**: Task says 'regardless of filtering' — assumed to mean ignore user-applied status filter but still exclude archived. If wrong, the fix is trivial (just toggle the archived flag).