### PR TITLE
IA-440 CLONE - Resolve an issue with Export to Excel on the Invoice page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -192,25 +192,7 @@ export class InvoiceController {
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
         summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
-    })
-    @ApiQuery({
-        name: 'status',
-        required: false,
-        enum: ['PAID', 'UNPAID', 'OVERDUE'],
-        description: 'Filter invoices by status',
+        description: 'Exports all non-archived invoices for the tenant to an Excel file, regardless of current pagination or filter state',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -221,10 +203,9 @@ export class InvoiceController {
     async exportToExcel(
         @Req() request: RequestWithTenant,
         @Res() response: Response,
-        @Query() paginationParams: PaginationParamsDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        const buffer = await this.invoiceService.exportToExcel(tenantId);
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -16,7 +16,7 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    exportToExcel(tenantId: string): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -104,11 +104,10 @@ export class InvoiceService implements IInvoiceService {
         await this.invoiceRepository.remove(id, tenantId);
     }
 
-    async exportToExcel(
-        tenantId: string,
-        paginationParams: PaginationParamsDto,
-    ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+    async exportToExcel(tenantId: string): Promise<Buffer> {
+        // Fetch all non-archived invoices for the tenant, ignoring pagination/filters,
+        // so that the exported file always contains the complete dataset.
+        const invoices = await this.invoiceRepository.findAllForExport(tenantId);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -41,6 +41,17 @@ export class InvoiceRepository {
         });
     }
 
+    /**
+     * Retrieves all non-archived invoices for a tenant without any pagination constraints.
+     * Used exclusively for the export-to-Excel flow to ensure all invoices are exported.
+     */
+    async findAllForExport(tenantId: string): Promise<Invoice[]> {
+        return this.invoiceRepository.find({
+            where: { tenantId, isArchived: false },
+            order: { issueDate: 'DESC' },
+        });
+    }
+
     async findById(id: string, tenantId: string): Promise<Invoice | null> {
         return this.invoiceRepository.findOne({
             where: { id, tenantId },

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -258,11 +258,11 @@ const InvoiceManagementPage: React.FC = () => {
     setPage(1); // Reset to first page when changing limit
   };
 
-  // Handle export to Excel
+  // Handle export to Excel — exports all non-archived invoices regardless of current page/filter state
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      const blob = await invoiceService.exportInvoices();
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,23 +80,12 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
-   * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * Export all invoices to Excel file.
+   * Exports the complete dataset for the tenant regardless of pagination or filter state.
    * @returns Promise<Blob>
    */
-  exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
-    status?: string,
-  ): Promise<Blob> => {
+  exportInvoices: async (): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
-      params: {
-        page,
-        limit,
-        ...(status && { status }),
-      },
       responseType: 'blob',
     });
     return response.data;


### PR DESCRIPTION
Implementation of IA-440

Currently, when a user tries to export invoices, only the invoices visible on a page are exported.
Expected result: all invoices, regardless of pagination and filtering, must be exported

# Implementation Plan

## Conceptual Checklist

- Trace the full export flow: frontend handler → service → API endpoint → backend service → repository
- Identify all pagination/filter constraints applied during export
- Decide on backend approach: new method vs modifying existing
- Ensure frontend stops sending pagination/filter params for export
- Maintain backward compatibility and tenant isolation
- Follow clean architecture (dependencies point inward)

## Overview

Remove pagination and filtering constraints from the invoice export flow so that all invoices (for the tenant) are exported to Excel regardless of the user's current page or filter state.

## Assumptions and Rules from CLAUDE.md

- Dependencies point inward: API → Application → Domain (project CLAUDE.md)
- Use DTOs for data transfer between layers (project CLAUDE.md)
- No business logic in infrastructure or presentation layers (project CLAUDE.md)
- ESLint runs before dev server; run `npm run lint:fix` after changes (project CLAUDE.md)
- Assumption: Archived invoices remain excluded from export
- Assumption: Status filter is ignored during export (per task description)

## Step-by-Step Implementation

1. **Add `findAllForExport` method to `InvoiceRepository`** (`api/src/application/repositories/invoice.repository.ts`)
- Query all non-archived invoices for tenantId without skip/take
- Order by issueDate DESC
- Dependencies: None

2. **Update `exportToExcel` in `InvoiceService`** (`api/src/application/invoices/invoice.service.ts`)
- Change method signature to accept only `tenantId` (remove `PaginationParamsDto`)
- Call new `findAllForExport` instead of `findAll`
- Dependencies: Step 1

3. **Update `IInvoiceService` interface** (`api/src/application/invoices/interfaces/invoice.service.interface.ts`)
- Update `exportToExcel` signature to remove `PaginationParamsDto`
- Dependencies: Step 2

4. **Update controller endpoint** (`api/src/api/controllers/invoice.controller.ts`)
- Remove `@Query() paginationParams` from `exportToExcel` method
- Remove `@ApiQuery` decorators for page/limit/status
- Call service with only `tenantId`
- Dependencies: Steps 2-3

5. **Update frontend service** (`client/src/modules/invoices/services/invoiceService.ts`)
- Remove page/limit/status params from `exportInvoices`
- Send GET to `/invoices/export/excel` with no query params
- Dependencies: Step 4

6. **Update frontend handler** (`client/src/modules/invoices/components/InvoiceManagementPage.tsx`)
- Call `invoiceService.exportInvoices()` with no arguments
- Dependencies: Step 5

7. **Lint and verify** — Run `npm run lint` in both `api/` and `client/`

## Error Handling and Uncertainties

- **Large datasets:** If a tenant has thousands of invoices, exporting all at once could cause memory issues. Consider streaming or chunked writes with ExcelJS if needed, but for now assume reasonable dataset sizes.
- **Timeout risk:** Large exports may exceed HTTP timeout. Monitor but likely acceptable for MVP.
- **Filter ambiguity:** Assumed filters are ignored per task description; if stakeholder wants filtered export, Step 2 would retain optional status param.