### PR TITLE
IA-448 Resolve an issue with export to Excel on the Invoice page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -35,6 +35,7 @@ import { InvoiceDto } from '../../application/invoices/dto/invoice.dto';
 import {
     PaginatedResponseDto,
     PaginationParamsDto,
+    ExportParamsDto,
 } from '../../application/invoices/dto/pagination.dto';
 import { Authorize } from '../../infrastructure/auth/decorators/authorize.decorator';
 import { RoleName } from '../../domain/enums/role-name.enum';
@@ -192,25 +193,19 @@ export class InvoiceController {
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
         summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
+        description: 'Exports all invoices to an Excel file based on filters (all pages exported)',
     })
     @ApiQuery({
         name: 'status',
         required: false,
         enum: ['PAID', 'UNPAID', 'OVERDUE'],
         description: 'Filter invoices by status',
+    })
+    @ApiQuery({
+        name: 'includeArchived',
+        required: false,
+        type: Boolean,
+        description: 'Include archived invoices in export',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -221,10 +216,10 @@ export class InvoiceController {
     async exportToExcel(
         @Req() request: RequestWithTenant,
         @Res() response: Response,
-        @Query() paginationParams: PaginationParamsDto,
+        @Query() exportParams: ExportParamsDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        const buffer = await this.invoiceService.exportToExcel(tenantId, exportParams);
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/dto/pagination.dto.ts
+++ b/api/src/application/invoices/dto/pagination.dto.ts
@@ -50,6 +50,30 @@ export class PaginationParamsDto {
     includeArchived?: boolean = false;
 }
 
+export class ExportParamsDto {
+    @ApiProperty({
+        description: 'Filter invoices by status',
+        example: 'PAID',
+        enum: ['PAID', 'UNPAID', 'OVERDUE'],
+        required: false,
+    })
+    @IsString()
+    @IsIn(['PAID', 'UNPAID', 'OVERDUE'])
+    @IsOptional()
+    status?: string;
+
+    @ApiProperty({
+        description: 'Include archived invoices in export',
+        example: false,
+        default: false,
+        required: false,
+    })
+    @IsBoolean()
+    @IsOptional()
+    @Transform(({ value }) => value === 'true' || value === true)
+    includeArchived?: boolean = false;
+}
+
 export class PaginatedResponseDto<T> {
     @ApiProperty({
         description: 'Array of items for the current page',

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -1,6 +1,5 @@
 import { InvoiceDto } from '../dto/invoice.dto';
-import { PaginatedResponseDto } from '../dto/pagination.dto';
-import { PaginationParamsDto } from '../dto/pagination.dto';
+import { PaginatedResponseDto, PaginationParamsDto, ExportParamsDto } from '../dto/pagination.dto';
 
 export const INVOICE_SERVICE = 'INVOICE_SERVICE';
 
@@ -16,7 +15,7 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    exportToExcel(tenantId: string, exportParams: ExportParamsDto): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -4,7 +4,7 @@ import { IInvoiceService } from './interfaces/invoice.service.interface';
 import { InvoiceRepository } from '../repositories/invoice.repository';
 import { InvoiceMapper } from './invoice.mapper';
 import { InvoiceDto } from './dto/invoice.dto';
-import { PaginatedResponseDto, PaginationParamsDto } from './dto/pagination.dto';
+import { PaginatedResponseDto, PaginationParamsDto, ExportParamsDto } from './dto/pagination.dto';
 import { Invoice } from '../../domain/entities/invoice.entity';
 import { InvoiceItem } from '../../domain/entities/invoice-item.entity';
 
@@ -106,9 +106,10 @@ export class InvoiceService implements IInvoiceService {
 
     async exportToExcel(
         tenantId: string,
-        paginationParams: PaginationParamsDto,
+        exportParams: ExportParamsDto,
     ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+        // Fetch all invoices matching the filters without any pagination constraints
+        const invoices = await this.invoiceRepository.findAllForExport(tenantId, exportParams);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Invoice } from '../../domain/entities/invoice.entity';
-import { PaginationParamsDto } from '../invoices/dto/pagination.dto';
+import { PaginationParamsDto, ExportParamsDto } from '../invoices/dto/pagination.dto';
 import { AnalyticsFiltersDto } from '../analytics/dto/analytics-filters.dto';
 
 @Injectable()
@@ -35,6 +35,29 @@ export class InvoiceRepository {
             where: whereClause,
             skip,
             take: limit,
+            order: {
+                issueDate: 'DESC',
+            },
+        });
+    }
+
+    async findAllForExport(
+        tenantId: string,
+        exportParams: ExportParamsDto,
+    ): Promise<Invoice[]> {
+        // Build where clause with optional status filter but without pagination
+        const whereClause: any = { tenantId };
+        if (exportParams.status) {
+            whereClause.status = exportParams.status;
+        }
+
+        // By default, exclude archived invoices unless explicitly requested
+        if (!exportParams.includeArchived) {
+            whereClause.isArchived = false;
+        }
+
+        return this.invoiceRepository.find({
+            where: whereClause,
             order: {
                 issueDate: 'DESC',
             },

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -258,11 +258,11 @@ const InvoiceManagementPage: React.FC = () => {
     setPage(1); // Reset to first page when changing limit
   };
 
-  // Handle export to Excel
+  // Handle export to Excel — exports ALL invoices matching the current filters (no pagination)
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      const blob = await invoiceService.exportInvoices(statusFilter || undefined, includeArchived);
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,22 +80,19 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
+   * Export all invoices to Excel file (ignores pagination — exports all matching records)
    * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * @param includeArchived - Include archived invoices in export (default: false)
    * @returns Promise<Blob>
    */
   exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
     status?: string,
+    includeArchived: boolean = false,
   ): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
       params: {
-        page,
-        limit,
         ...(status && { status }),
+        includeArchived,
       },
       responseType: 'blob',
     });


### PR DESCRIPTION
Implementation of IA-448

Currently, when a user tries to export invoices, only the invoices visible on a page are exported.
Expected result: all invoices, regardless of pagination and filtering, must be exported

# Implementation Plan

## Conceptual Checklist

- Trace the full export data flow from UI button to DB query
- Identify minimal changes needed at each layer
- Preserve existing filter behavior (status) while removing pagination
- Follow clean architecture: changes flow API → Application → Infrastructure
- Ensure client stops sending pagination params for export

## Overview

Modify the invoice export flow so that clicking "Export to Excel" fetches ALL invoices (matching current status filter) instead of only the current page. Changes span 4 files across client and API.

## Assumptions and Rules from CLAUDE.md

- Dependencies point inward: API → Application → Domain (project CLAUDE.md)
- Use DTOs for data transfer between layers (project CLAUDE.md)
- Run `npm run lint` before considering work done (project CLAUDE.md)
- Status filter is preserved; only pagination (page/limit) is removed from export

## Step-by-Step Implementation

1. **API Repository — Add `findAllWithoutPagination` method**
- File: `api/src/application/repositories/invoice.repository.ts`
- Add method that queries with `where` clause (status, archived) but no `skip`/`take`
- Alternatively, modify `findAll` to skip pagination when `limit` is undefined/0

2. **API Service — Update `exportToExcel` to skip pagination**
- File: `api/src/application/invoices/invoice.service.ts` (line 107-111)
- Call repository without pagination constraints
- Keep status and includeArchived filters

3. **API Controller — Remove page/limit from export endpoint**
- File: `api/src/api/controllers/invoice.controller.ts` (line 191-232)
- Remove `page` and `limit` `@ApiQuery` decorators from export endpoint
- Keep `status` query param; optionally use a lighter DTO without page/limit

4. **Client Service — Remove pagination params from export call**
- File: `client/src/modules/invoices/services/invoiceService.ts` (line 89-103)
- Change `exportInvoices` signature to only accept optional `status`
- Remove `page` and `limit` from request params

5. **Client Component — Update export handler**
- File: `client/src/modules/invoices/components/InvoiceManagementPage.tsx` (line 262-265)
- Change `handleExportToExcel` to call `exportInvoices(statusFilter)` without page/limit

6. **Lint & Test**
- Run `cd api && npm run lint` and `cd client && npm run lint`
- Verify no regressions in existing functionality

## Error Handling and Uncertainties

- **Large dataset risk:** ExcelJS `writeBuffer()` loads all data in memory. For very large tenants this could cause OOM. Mitigation: acceptable for now; add streaming if needed later.
- **Client-side search/date filters:** These are applied post-fetch on the UI and don't affect the export endpoint. No changes needed there.
- **DTO reuse:** Could create a separate `ExportParamsDto` without page/limit, or make page/limit truly optional in existing DTO. Separate DTO is cleaner per clean architecture rules.