### PR TITLE
IA-450 Resolve an issue with export to Excel on the Invoice page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -36,6 +36,7 @@ import {
     PaginatedResponseDto,
     PaginationParamsDto,
 } from '../../application/invoices/dto/pagination.dto';
+import { ExportFilterDto } from '../../application/invoices/dto/export-filter.dto';
 import { Authorize } from '../../infrastructure/auth/decorators/authorize.decorator';
 import { RoleName } from '../../domain/enums/role-name.enum';
 import { RequestWithTenant } from '../../infrastructure/middleware/request-with-tenant.interface';
@@ -192,25 +193,19 @@ export class InvoiceController {
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
         summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
+        description: 'Exports ALL matching invoices to an Excel file (no pagination). Use status and includeArchived filters to narrow the export.',
     })
     @ApiQuery({
         name: 'status',
         required: false,
         enum: ['PAID', 'UNPAID', 'OVERDUE'],
-        description: 'Filter invoices by status',
+        description: 'Filter exported invoices by status',
+    })
+    @ApiQuery({
+        name: 'includeArchived',
+        required: false,
+        type: Boolean,
+        description: 'Include archived invoices in the export',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -221,10 +216,10 @@ export class InvoiceController {
     async exportToExcel(
         @Req() request: RequestWithTenant,
         @Res() response: Response,
-        @Query() paginationParams: PaginationParamsDto,
+        @Query() filters: ExportFilterDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        const buffer = await this.invoiceService.exportToExcel(tenantId, filters);
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/dto/export-filter.dto.ts
+++ b/api/src/application/invoices/dto/export-filter.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsIn, IsOptional, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+/**
+ * DTO for filtering invoices during export.
+ * Intentionally excludes pagination parameters so that ALL matching invoices
+ * are included in the exported file rather than just a single page.
+ */
+export class ExportFilterDto {
+    @ApiProperty({
+        description: 'Filter exported invoices by status',
+        example: 'PAID',
+        enum: ['PAID', 'UNPAID', 'OVERDUE'],
+        required: false,
+    })
+    @IsString()
+    @IsIn(['PAID', 'UNPAID', 'OVERDUE'])
+    @IsOptional()
+    status?: string;
+
+    @ApiProperty({
+        description: 'Include archived invoices in the export',
+        example: false,
+        default: false,
+        required: false,
+    })
+    @IsBoolean()
+    @IsOptional()
+    @Transform(({ value }) => value === 'true' || value === true)
+    includeArchived?: boolean = false;
+}

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -1,6 +1,7 @@
 import { InvoiceDto } from '../dto/invoice.dto';
 import { PaginatedResponseDto } from '../dto/pagination.dto';
 import { PaginationParamsDto } from '../dto/pagination.dto';
+import { ExportFilterDto } from '../dto/export-filter.dto';
 
 export const INVOICE_SERVICE = 'INVOICE_SERVICE';
 
@@ -16,7 +17,7 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    exportToExcel(tenantId: string, filters: ExportFilterDto): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -5,6 +5,7 @@ import { InvoiceRepository } from '../repositories/invoice.repository';
 import { InvoiceMapper } from './invoice.mapper';
 import { InvoiceDto } from './dto/invoice.dto';
 import { PaginatedResponseDto, PaginationParamsDto } from './dto/pagination.dto';
+import { ExportFilterDto } from './dto/export-filter.dto';
 import { Invoice } from '../../domain/entities/invoice.entity';
 import { InvoiceItem } from '../../domain/entities/invoice-item.entity';
 
@@ -106,9 +107,11 @@ export class InvoiceService implements IInvoiceService {
 
     async exportToExcel(
         tenantId: string,
-        paginationParams: PaginationParamsDto,
+        filters: ExportFilterDto,
     ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+        // Use findAllForExport to retrieve every matching invoice without pagination,
+        // ensuring the exported file contains all records rather than a single page.
+        const invoices = await this.invoiceRepository.findAllForExport(tenantId, filters);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -41,6 +41,34 @@ export class InvoiceRepository {
         });
     }
 
+    /**
+     * Retrieves all invoices for a tenant without pagination, intended for export operations.
+     * Supports optional status and includeArchived filters so the export mirrors
+     * the user's current view, but always returns every matching record.
+     */
+    async findAllForExport(
+        tenantId: string,
+        filters: { status?: string; includeArchived?: boolean },
+    ): Promise<Invoice[]> {
+        const whereClause: any = { tenantId };
+
+        if (filters.status) {
+            whereClause.status = filters.status;
+        }
+
+        // Exclude archived invoices unless explicitly requested
+        if (!filters.includeArchived) {
+            whereClause.isArchived = false;
+        }
+
+        return this.invoiceRepository.find({
+            where: whereClause,
+            order: {
+                issueDate: 'DESC',
+            },
+        });
+    }
+
     async findById(id: string, tenantId: string): Promise<Invoice | null> {
         return this.invoiceRepository.findOne({
             where: { id, tenantId },

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -262,7 +262,10 @@ const InvoiceManagementPage: React.FC = () => {
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      // Pass the active status and includeArchived filters so the export mirrors
+      // the current view, but without any pagination limit so all matching
+      // invoices are included in the downloaded file.
+      const blob = await invoiceService.exportInvoices(statusFilter || undefined, includeArchived);
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,22 +80,22 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
+   * Export all matching invoices to an Excel file.
+   * Unlike the paginated list endpoint, this returns every record that matches
+   * the provided filters so the downloaded file is never limited to one page.
+   *
    * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * @param includeArchived - Whether to include archived invoices (default: false)
    * @returns Promise<Blob>
    */
   exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
     status?: string,
+    includeArchived: boolean = false,
   ): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
       params: {
-        page,
-        limit,
         ...(status && { status }),
+        includeArchived,
       },
       responseType: 'blob',
     });


### PR DESCRIPTION
Implementation of IA-450

Resolve an issue with export to Excel on the Invoice page

# Implementation Plan

## Conceptual Checklist

- Confirm which files need changes on the API side (repository, service, controller/DTO)
- Confirm which files need changes on the client side (service, page component)
- Decide how to handle pagination removal on the API (new method vs. optional flag)
- Ensure all current server-side filters (status, includeArchived) are forwarded to the export endpoint
- Verify no breaking changes to the existing list endpoint

## Overview

The export endpoint currently reuses the paginated `findAll` repository call, so only the current page is exported. The fix removes pagination from the export path on the API while passing all relevant server-side filters (status, includeArchived) from the client.

## Assumptions and Rules from CLAUDE.md

- Dependencies point inward: API → Application → Domain (project CLAUDE.md).
- Repository is the correct layer for data access; service calls repository (project CLAUDE.md).
- DTOs are used for data transfer between layers (project CLAUDE.md).
- Linting must pass before dev servers start; run `npm run lint:fix` after changes (project CLAUDE.md).
- Assumption: export respects active status/includeArchived filters but ignores pagination.
- Assumption: client-side-only filters (searchQuery, dateFilter) are out of scope for this fix.

## Step-by-Step Implementation

1. **API – Repository** (`api/src/application/repositories/invoice.repository.ts`)
- Add `findAllForExport(tenantId, filters: { status?: string; includeArchived?: boolean }): Promise` that uses `find()` instead of `findAndCount()` with no `skip`/`take`.
- Dependencies: None.
- Tools/Files: Edit `invoice.repository.ts`.

2. **API – Create Export Filter DTO** (`api/src/application/invoices/dto/`)
- Create `ExportFilterDto` with optional `status` and `includeArchived` fields (no `page`/`limit`).
- Dependencies: Step 1.
- Tools/Files: Write new `export-filter.dto.ts`.

3. **API – Service** (`api/src/application/invoices/invoice.service.ts`)
- Change `exportToExcel(tenantId, paginationParams)` signature to accept `ExportFilterDto`.
- Call `invoiceRepository.findAllForExport()` instead of `findAll()`.
- Dependencies: Steps 1–2.
- Tools/Files: Edit `invoice.service.ts`.

4. **API – Controller** (`api/src/api/controllers/invoice.controller.ts`)
- Update `exportToExcel` controller method to use `@Query() filters: ExportFilterDto` instead of `PaginationParamsDto`.
- Dependencies: Steps 2–3.
- Tools/Files: Edit `invoice.controller.ts`.

5. **Client – Service** (`client/src/modules/invoices/services/invoiceService.ts`)
- Update `exportInvoices` signature to `(status?: string, includeArchived?: boolean): Promise`.
- Remove `page` and `limit` params; send only `status` and `includeArchived` as query params.
- Dependencies: Step 4.
- Tools/Files: Edit `invoiceService.ts`.

6. **Client – Page Component** (`client/src/modules/invoices/components/InvoiceManagementPage.tsx`)
- Update `handleExportToExcel` to call `invoiceService.exportInvoices(statusFilter || undefined, includeArchived)`.
- Remove `page` and `limit` arguments.
- Dependencies: Step 5.
- Tools/Files: Edit `InvoiceManagementPage.tsx`.

## Error Handling and Uncertainties

- **Filter scope ambiguity**: If the user wants ALL invoices with no filters, Step 2 becomes a no-DTO call; Step 3/4 become simpler. The plan above assumes filters are preserved.
- **Large result sets**: No row cap is implemented; very large tenants could time out. Mitigation: acceptable for now; can add a streaming/background-job approach later.
- **searchQuery / dateFilter**: These are client-side-only filters and are intentionally out of scope. Moving them server-side would require a separate API story.
- **Linting**: Run `npm run lint:fix` in both `api/` and `client/` after changes before committing.