### PR TITLE
IA-457 Add new black-purple theme

### DIFF
--- a/client/src/modules/invoices/components/ThemeToggle.tsx
+++ b/client/src/modules/invoices/components/ThemeToggle.tsx
@@ -3,23 +3,39 @@ import { IconButton, Tooltip } from '@mui/material';
 import { Palette as PaletteIcon } from '@mui/icons-material';
 import { useThemeMode } from '../../../themes/ThemeContext';
 
+// Map of the next theme in the rotation for display in the tooltip
+const NEXT_THEME_LABEL: Record<string, string> = {
+  dark: 'Pink-Grey',
+  pinkGrey: 'Charcoal Citrus',
+  charcoalCitrus: 'Black Purple',
+  blackPurple: 'Dark Blue',
+};
+
+// Accent color per theme for the icon
+const THEME_ACCENT: Record<string, { color: string; hoverBg: string }> = {
+  dark: { color: '#90CAF9', hoverBg: 'rgba(144, 202, 249, 0.08)' },
+  pinkGrey: { color: '#FFC0CB', hoverBg: 'rgba(255, 192, 203, 0.08)' },
+  charcoalCitrus: { color: '#F4F4A1', hoverBg: 'rgba(244, 244, 161, 0.08)' },
+  blackPurple: { color: '#BB86FC', hoverBg: 'rgba(187, 134, 252, 0.08)' },
+};
+
 /**
- * Theme toggle button for switching between dark and pink-grey themes
+ * Theme toggle button for cycling through the available themes
  * Only used on the invoice management page
  */
 const ThemeToggle: React.FC = () => {
   const { themeMode, toggleTheme } = useThemeMode();
+  const accent = THEME_ACCENT[themeMode] ?? THEME_ACCENT.dark;
+  const nextLabel = NEXT_THEME_LABEL[themeMode] ?? 'Dark Blue';
 
   return (
-    <Tooltip title={`Switch to ${themeMode === 'dark' ? 'Pink-Grey' : 'Dark Blue'} theme`}>
+    <Tooltip title={`Switch to ${nextLabel} theme`}>
       <IconButton
         onClick={toggleTheme}
         sx={{
-          color: themeMode === 'pinkGrey' ? '#FFC0CB' : '#90CAF9',
+          color: accent.color,
           '&:hover': {
-            backgroundColor: themeMode === 'pinkGrey'
-              ? 'rgba(255, 192, 203, 0.08)'
-              : 'rgba(144, 202, 249, 0.08)',
+            backgroundColor: accent.hoverBg,
           },
         }}
         aria-label="Toggle theme"

--- a/client/src/themes/ThemeContext.tsx
+++ b/client/src/themes/ThemeContext.tsx
@@ -3,8 +3,9 @@ import { ThemeProvider as MuiThemeProvider, Theme } from '@mui/material';
 import { darkTheme } from './darkTheme';
 import { pinkGreyTheme } from './pinkGreyTheme';
 import { charcoalCitrusTheme } from './charcoalCitrusTheme';
+import { blackPurpleTheme } from './blackPurpleTheme';
 
-type ThemeMode = 'dark' | 'pinkGrey' | 'charcoalCitrus';
+type ThemeMode = 'dark' | 'pinkGrey' | 'charcoalCitrus' | 'blackPurple';
 
 interface ThemeInfo {
   theme: Theme;
@@ -29,7 +30,11 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     // Load theme preference from localStorage
     try {
       const stored = localStorage.getItem(THEME_STORAGE_KEY);
-      if (stored === 'pinkGrey' || stored === 'charcoalCitrus') {
+      if (
+        stored === 'pinkGrey' ||
+        stored === 'charcoalCitrus' ||
+        stored === 'blackPurple'
+      ) {
         return stored as ThemeMode;
       }
       return 'dark';
@@ -51,6 +56,12 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
           displayName: '🍋 Charcoal Citrus',
           iconColor: '#FF8C00', // Orange icon
         };
+      case 'blackPurple':
+        return {
+          theme: blackPurpleTheme,
+          displayName: '🟣 Black Purple',
+          iconColor: '#BB86FC', // Purple icon
+        };
       case 'dark':
       default:
         return {
@@ -70,6 +81,8 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         newMode = 'pinkGrey';
       } else if (prev === 'pinkGrey') {
         newMode = 'charcoalCitrus';
+      } else if (prev === 'charcoalCitrus') {
+        newMode = 'blackPurple';
       } else {
         newMode = 'dark';
       }

--- a/client/src/themes/blackPurpleTheme.ts
+++ b/client/src/themes/blackPurpleTheme.ts
@@ -1,0 +1,197 @@
+import { createTheme } from '@mui/material';
+import { darken, lighten } from '@mui/material/styles';
+
+// Black Purple Theme - Deep Black with Vibrant Purple accents
+export const blackPurpleTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#BB86FC', // Vibrant Purple
+      light: lighten('#BB86FC', 0.15),
+      dark: darken('#BB86FC', 0.15),
+      contrastText: '#000000',
+    },
+    secondary: {
+      main: '#7C4DFF', // Deep Purple accent
+      light: lighten('#7C4DFF', 0.15),
+      dark: darken('#7C4DFF', 0.15),
+      contrastText: '#FFFFFF',
+    },
+    background: {
+      default: '#0D0D0D', // Near-black
+      paper: '#1A1A1A', // Slightly lighter black for cards
+    },
+    text: {
+      primary: '#FFFFFF',
+      secondary: '#B3B3B3',
+    },
+    error: {
+      main: '#F87171',
+    },
+    warning: {
+      main: '#FBBF24',
+    },
+    info: {
+      main: '#60A5FA',
+    },
+    success: {
+      main: '#34D399',
+    },
+    invoiceStatus: {
+      paid: lighten('#BB86FC', 0.15), // Lighter purple for paid
+      unpaid: '#BB86FC', // Mid purple for unpaid
+      overdue: darken('#BB86FC', 0.3), // Darker purple for overdue
+    },
+    divider: 'rgba(255, 255, 255, 0.12)',
+  },
+  typography: {
+    fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+    h1: {
+      fontWeight: 700,
+    },
+    h2: {
+      fontWeight: 700,
+    },
+    h3: {
+      fontWeight: 600,
+    },
+    h4: {
+      fontWeight: 600,
+    },
+    h5: {
+      fontWeight: 600,
+    },
+    h6: {
+      fontWeight: 600,
+    },
+    button: {
+      fontWeight: 600,
+      textTransform: 'none',
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          boxShadow: '0 1px 2px rgba(0, 0, 0, 0.25)',
+          padding: '8px 16px',
+          transition: 'all 0.2s ease',
+          '&:hover': {
+            boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+            transform: 'translateY(-1px)',
+          },
+        },
+        contained: {
+          backgroundColor: '#BB86FC',
+          color: '#000000',
+          '&:hover': {
+            backgroundColor: darken('#BB86FC', 0.15),
+          },
+        },
+        outlined: {
+          borderColor: lighten('#BB86FC', 0.1),
+          color: '#BB86FC',
+          '&:hover': {
+            borderColor: '#BB86FC',
+            backgroundColor: 'rgba(187, 134, 252, 0.08)',
+          },
+        },
+      },
+    },
+    MuiSelect: {
+      styleOverrides: {
+        root: {
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#BB86FC',
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: 'rgba(255, 255, 255, 0.23)',
+          },
+        },
+      },
+    },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          '&.Mui-selected': {
+            backgroundColor: 'rgba(187, 134, 252, 0.16)',
+          },
+          '&.Mui-selected:hover': {
+            backgroundColor: 'rgba(187, 134, 252, 0.24)',
+          },
+          '&:hover': {
+            backgroundColor: 'rgba(255, 255, 255, 0.08)',
+          },
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.5), 0 1px 2px rgba(0, 0, 0, 0.3)',
+          border: '1px solid rgba(255, 255, 255, 0.12)',
+          backgroundImage: 'none',
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.5), 0 1px 2px rgba(0, 0, 0, 0.3)',
+        },
+      },
+    },
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.5)',
+          backgroundImage: 'none',
+          backgroundColor: '#1A1A1A',
+          borderBottom: '1px solid rgba(255, 255, 255, 0.12)',
+        },
+      },
+    },
+    MuiTableHead: {
+      styleOverrides: {
+        root: {
+          '& .MuiTableCell-root': {
+            fontWeight: 600,
+            color: '#FFFFFF',
+            backgroundColor: '#1A1A1A',
+            borderBottom: '2px solid rgba(255, 255, 255, 0.12)',
+          },
+        },
+      },
+    },
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '& fieldset': {
+              borderColor: 'rgba(255, 255, 255, 0.23)',
+            },
+            '&:hover fieldset': {
+              borderColor: 'rgba(255, 255, 255, 0.4)',
+            },
+            '&.Mui-focused fieldset': {
+              borderColor: '#BB86FC',
+            },
+          },
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          fontWeight: 500,
+        },
+      },
+    },
+  },
+});

--- a/client/src/themes/index.ts
+++ b/client/src/themes/index.ts
@@ -1,8 +1,9 @@
 import { darkTheme } from './darkTheme';
 import { pinkGreyTheme } from './pinkGreyTheme';
 import { charcoalCitrusTheme } from './charcoalCitrusTheme';
+import { blackPurpleTheme } from './blackPurpleTheme';
 
 // Export the dark theme as the default theme
 export const theme = darkTheme;
 
-export { darkTheme, pinkGreyTheme, charcoalCitrusTheme };
+export { darkTheme, pinkGreyTheme, charcoalCitrusTheme, blackPurpleTheme };


### PR DESCRIPTION
Implementation of IA-457

Add new black-purple theme

# Implementation Plan

## Conceptual Checklist
- Review existing theme files and the ThemeContext cycle.
- Define black-purple palette matching dark-mode conventions.
- Create the new theme file mirroring existing structure.
- Register the theme in the barrel export and context.
- Update toggle UI tooltips/cycle and verify localStorage key accepts new value.
- Run lint to validate.

## Overview
Add a fourth MUI theme (`blackPurpleTheme`) to `client/src/themes/`, wire it into `ThemeContext.tsx` so `toggleTheme` cycles through it, and expose it via the existing palette toggle in `MainLayout` and `ThemeToggle`.

## Assumptions and Rules from CLAUDE.md
- Project CLAUDE.md: client is React 19 + MUI + Emotion; run `npm run lint:fix` and follow ESLint/Prettier.
- Client CLAUDE.md: module-based architecture; themes live outside modules in `src/themes/`.
- Global rules: dependencies point inward — no business logic change, presentation only.
- Ambiguity: exact hex, name, cycle position — resolved via assumption in questions (default: #0D0D0D/#1A1A1A/#BB86FC, key `blackPurple`, appended to cycle).

## Step-by-Step Implementation
1. Create `client/src/themes/blackPurpleTheme.ts`
- Tools/Files: Write. Mirror `charcoalCitrusTheme.ts` structure: `createTheme({ palette: { mode: 'dark', primary: { main: '#BB86FC' }, secondary: { main: '#7C4DFF' }, background: { default: '#0D0D0D', paper: '#1A1A1A' }, invoiceStatus: { paid, unpaid, overdue } }, components: {...same overrides adapted to purple accents} })`.
2. Export from `client/src/themes/index.ts`
- Tools/Files: Edit. Add `export { blackPurpleTheme } from './blackPurpleTheme';`.
3. Update `client/src/themes/ThemeContext.tsx`
- Extend `ThemeMode` union to include `'blackPurple'`.
- Update localStorage read guard to accept new value.
- Add case in `getThemeInfo` with displayName '🟣 Black Purple' and `iconColor: '#BB86FC'`.
- Extend `toggleTheme` cycle: charcoalCitrus → blackPurple → dark.
4. Update `client/src/modules/invoices/components/ThemeToggle.tsx`
- Refresh stale tooltip text to reflect four themes.
5. Lint: run `npm run lint:fix` in `client/`.

## Error Handling and Uncertainties
- Color choices are assumptions; confirm with designer if brand purple is specified.
- Component overrides use inlined hex; ensure contrast (WCAG AA) on purple buttons.
- If users have `charcoalCitrus` in localStorage, behavior unchanged; new key only set after user toggles.
- No tests exist for themes; manual verification by toggling through all four in dev.