### PR TITLE
IA-456 Prepare integration tests setup

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -19,4 +19,24 @@ export default tseslint.config(
     },
     rules: {},
   },
+  // Allow Jest globals (`describe`, `it`, `expect`, `jest`, ...) inside
+  // spec files and the shared test harness without importing them.
+  {
+    files: ['**/*.spec.{ts,tsx}', 'src/test-utils/**/*.{ts,tsx}'],
+    languageOptions: {
+      globals: {
+        ...globals.jest,
+        ...globals.node,
+      },
+    },
+    rules: {
+      // Mocks frequently accept an intentionally-unused parameter to match
+      // the real signature (e.g. BroadcastChannel#postMessage). Relax the
+      // unused-args rule where a leading underscore marks the intent.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
+  },
 );

--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -1,0 +1,76 @@
+/**
+ * Jest configuration for client integration tests.
+ *
+ * Goals:
+ * - Run React 19 + TypeScript tests in a jsdom environment.
+ * - Transform TS/TSX via ts-jest to CommonJS so `jest.mock()` works reliably
+ *   for all modules (including ESM-published packages like @clerk/clerk-react
+ *   and MSW v2). This keeps the test harness simple and predictable — we can
+ *   revisit Jest's experimental ESM mode once it stabilises.
+ * - Provide alias + static-asset stubs so component imports don't break.
+ *
+ * Uses the `.cjs` extension so Jest can load this config directly without a
+ * TypeScript loader, even though the surrounding package is `"type": "module"`.
+ */
+
+/** @type {import('jest').Config} */
+const config = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  rootDir: '.',
+  roots: ['<rootDir>/src'],
+
+  // Match collocated specs (e.g. `foo.spec.tsx` next to source) and shared harness specs.
+  testMatch: ['<rootDir>/src/**/*.spec.(ts|tsx)'],
+
+  // Setup lifecycle.
+  // - setupFiles: runs BEFORE the test framework is installed. Good for env/polyfills.
+  // - setupFilesAfterEnv: runs AFTER the test framework is installed.
+  //   Good for jest-dom matchers and MSW server lifecycle hooks.
+  setupFiles: ['<rootDir>/src/test-utils/jest.polyfills.ts'],
+  setupFilesAfterEnv: ['<rootDir>/src/test-utils/setupTests.ts'],
+
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+
+  // ts-jest (CJS) with the dedicated test tsconfig.
+  transform: {
+    '^.+\\.(ts|tsx|js|jsx)$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.test.json',
+        isolatedModules: true,
+        diagnostics: {
+          // Allow JS transforms without requiring full TS compilation of dep code.
+          ignoreCodes: ['TS151001'],
+        },
+      },
+    ],
+  },
+
+  // Default Jest skips node_modules for transforms. MSW v2, Clerk and a few of
+  // their dependencies publish ESM only, so we opt them in to ts-jest's pipeline.
+  transformIgnorePatterns: [
+    'node_modules/(?!(msw|@mswjs|@bundled-es-modules|@clerk|@tanstack|uuid|until-async|strict-event-emitter|tough-cookie|headers-polyfill)/)',
+  ],
+
+  moduleNameMapper: {
+    // Path alias used in the app (matches Vite's `@/` convention if adopted later).
+    '^@/(.*)$': '<rootDir>/src/$1',
+
+    // Strip the ESM `.js` suffix some packages use in their published output.
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+
+    // Stub out CSS/SCSS modules so component imports don't break.
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+
+    // Stub static assets so importing images/fonts in components doesn't fail.
+    '\\.(jpg|jpeg|png|gif|webp|svg|woff|woff2|ttf|eot)$':
+      '<rootDir>/src/test-utils/fileMock.ts',
+  },
+
+  clearMocks: true,
+  resetMocks: false,
+  restoreMocks: true,
+};
+
+module.exports = config;

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,8 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,scss}\"",
     "preview": "vite preview",
     "test": "jest --passWithNoTests",
+    "test:watch": "jest --watch",
+    "test:ci": "jest --ci --passWithNoTests",
     "prepare": "cd .. && husky install .husky"
   },
   "dependencies": {
@@ -42,6 +44,9 @@
   "devDependencies": {
     "@clerk/types": "^4.53.0",
     "@eslint/js": "^9.21.0",
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/dompurify": "^3.0.5",
     "@types/jest": "^29.5.14",
     "@types/react": "^19.0.10",
@@ -53,11 +58,15 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
     "husky": "^8.0.3",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "msw": "^2.6.0",
     "prettier": "^3.2.5",
     "ts-jest": "^29.3.2",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "whatwg-fetch": "^3.6.20"
   }
 }

--- a/client/src/test-utils/clerkMock.ts
+++ b/client/src/test-utils/clerkMock.ts
@@ -1,0 +1,135 @@
+/**
+ * Centralised mock for `@clerk/clerk-react`.
+ *
+ * The real SDK performs network calls, reads window state, and otherwise
+ * misbehaves inside jsdom. We swap it out with a lightweight stub whose
+ * returned user/roles can be reconfigured per-test via `setTestUser(...)`.
+ *
+ * Usage (from a spec file):
+ *
+ *   import { setTestUser } from '@/test-utils/clerkMock';
+ *   setTestUser({ roles: ['Super Admin'] });
+ *
+ * The `jest.mock` call lives at module scope. Because this file is loaded
+ * via `setupTests.ts` (which Jest runs before any test file), the mock is
+ * registered before any spec imports `@clerk/clerk-react`, so every test
+ * gets the stub. Tests can further refine the current user via
+ * `setTestUser(...)` without having to re-declare the mock.
+ */
+import React from 'react';
+
+export interface TestUser {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  emailAddress: string;
+  roles: string[];
+  /** Arbitrary additional public metadata fields merged into the mock user. */
+  publicMetadata?: Record<string, unknown>;
+}
+
+const DEFAULT_USER: TestUser = {
+  id: 'user_test_default',
+  firstName: 'Test',
+  lastName: 'User',
+  emailAddress: 'test.user@example.com',
+  roles: [],
+  publicMetadata: {},
+};
+
+// Mutable state so individual tests can override the "current" user without
+// having to re-issue `jest.mock` each time.
+let currentUser: TestUser = { ...DEFAULT_USER };
+let signedIn = true;
+
+/** Override the mock Clerk user for the duration of a single test. */
+export const setTestUser = (overrides: Partial<TestUser>): void => {
+  currentUser = { ...DEFAULT_USER, ...currentUser, ...overrides };
+  signedIn = true;
+};
+
+/** Simulate a signed-out user. */
+export const setSignedOut = (): void => {
+  signedIn = false;
+};
+
+/** Restore defaults — invoked from `setupTests.ts`'s `afterEach`. */
+export const resetClerkMock = (): void => {
+  currentUser = { ...DEFAULT_USER };
+  signedIn = true;
+};
+
+/** Read the active mock user (exposed for assertions / debugging). */
+export const getTestUser = (): TestUser => currentUser;
+
+const buildClerkUser = () => ({
+  id: currentUser.id,
+  firstName: currentUser.firstName,
+  lastName: currentUser.lastName,
+  primaryEmailAddress: { emailAddress: currentUser.emailAddress },
+  emailAddresses: [{ emailAddress: currentUser.emailAddress }],
+  publicMetadata: {
+    roles: currentUser.roles,
+    ...(currentUser.publicMetadata ?? {}),
+  },
+});
+
+// Installing the mock. Because this module is imported by
+// `setupTests.ts` (via `setupFilesAfterEnv`), this call runs before any
+// test file imports `@clerk/clerk-react`, so Jest's module registry swaps
+// in the factory below. The factory returns stable function references
+// whose bodies close over `currentUser` / `signedIn` — so updates from
+// `setTestUser(...)` take effect on the very next hook call without needing
+// to re-register the mock.
+jest.mock('@clerk/clerk-react', () => {
+  const passThrough = ({ children }: { children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children);
+
+  return {
+    __esModule: true,
+
+    // Providers — render children as-is; real auth is irrelevant for tests.
+    ClerkProvider: passThrough,
+    ClerkLoaded: passThrough,
+    ClerkLoading: () => null,
+
+    // Visibility gates keyed off of the mock signed-in flag.
+    SignedIn: ({ children }: { children?: React.ReactNode }) =>
+      signedIn ? React.createElement(React.Fragment, null, children) : null,
+    SignedOut: ({ children }: { children?: React.ReactNode }) =>
+      !signedIn ? React.createElement(React.Fragment, null, children) : null,
+
+    // UI surfaces reduced to predictable test stubs.
+    SignIn: () => React.createElement('div', { 'data-testid': 'clerk-sign-in' }),
+    SignUp: () => React.createElement('div', { 'data-testid': 'clerk-sign-up' }),
+    UserButton: () => React.createElement('div', { 'data-testid': 'clerk-user-button' }),
+
+    // Hooks.
+    useUser: () => ({
+      isLoaded: true,
+      isSignedIn: signedIn,
+      user: signedIn ? buildClerkUser() : null,
+    }),
+    useAuth: () => ({
+      isLoaded: true,
+      isSignedIn: signedIn,
+      userId: signedIn ? currentUser.id : null,
+      sessionId: signedIn ? 'sess_test' : null,
+      orgId: null,
+      orgRole: null,
+      orgSlug: null,
+      getToken: jest.fn().mockResolvedValue(signedIn ? 'test-token' : null),
+      signOut: jest.fn().mockResolvedValue(undefined),
+    }),
+    useClerk: () => ({
+      signOut: jest.fn().mockResolvedValue(undefined),
+      openSignIn: jest.fn(),
+      openSignUp: jest.fn(),
+    }),
+    useSession: () => ({
+      isLoaded: true,
+      isSignedIn: signedIn,
+      session: signedIn ? { id: 'sess_test' } : null,
+    }),
+  };
+});

--- a/client/src/test-utils/fileMock.ts
+++ b/client/src/test-utils/fileMock.ts
@@ -1,0 +1,6 @@
+/**
+ * Static asset stub used by Jest's `moduleNameMapper` for non-JS files
+ * (images, fonts, etc.). Returning a string keeps `<img src={logo} />`
+ * style imports from crashing tests without pulling in real bundlers.
+ */
+export default 'test-file-stub';

--- a/client/src/test-utils/handlers/index.ts
+++ b/client/src/test-utils/handlers/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Aggregates MSW request handlers contributed by each feature module.
+ *
+ * Keep this file thin: per-module handlers live under their own folder
+ * (e.g. `./tenants`) so that future tests colocate fixtures with the
+ * module they cover. The default aggregate is empty on purpose —
+ * infrastructure-only setup, no real API contracts committed yet.
+ */
+import type { RequestHandler } from 'msw';
+
+import { tenantsHandlers } from './tenants';
+import { usersHandlers } from './users';
+import { secretsHandlers } from './secrets';
+import { invoicesHandlers } from './invoices';
+
+export const handlers: RequestHandler[] = [
+  ...tenantsHandlers,
+  ...usersHandlers,
+  ...secretsHandlers,
+  ...invoicesHandlers,
+];

--- a/client/src/test-utils/handlers/invoices/index.ts
+++ b/client/src/test-utils/handlers/invoices/index.ts
@@ -1,0 +1,7 @@
+/**
+ * MSW handlers for the `invoices` module. Add request handlers here as
+ * the corresponding integration tests arrive — e.g. `http.get('/api/invoices', ...)`.
+ */
+import type { RequestHandler } from 'msw';
+
+export const invoicesHandlers: RequestHandler[] = [];

--- a/client/src/test-utils/handlers/secrets/index.ts
+++ b/client/src/test-utils/handlers/secrets/index.ts
@@ -1,0 +1,7 @@
+/**
+ * MSW handlers for the `secrets` module. Add request handlers here as
+ * the corresponding integration tests arrive — e.g. `http.get('/api/secrets', ...)`.
+ */
+import type { RequestHandler } from 'msw';
+
+export const secretsHandlers: RequestHandler[] = [];

--- a/client/src/test-utils/handlers/tenants/index.ts
+++ b/client/src/test-utils/handlers/tenants/index.ts
@@ -1,0 +1,7 @@
+/**
+ * MSW handlers for the `tenants` module. Add request handlers here as
+ * the corresponding integration tests arrive — e.g. `http.get('/api/tenants', ...)`.
+ */
+import type { RequestHandler } from 'msw';
+
+export const tenantsHandlers: RequestHandler[] = [];

--- a/client/src/test-utils/handlers/users/index.ts
+++ b/client/src/test-utils/handlers/users/index.ts
@@ -1,0 +1,7 @@
+/**
+ * MSW handlers for the `users` module. Add request handlers here as
+ * the corresponding integration tests arrive — e.g. `http.get('/api/users', ...)`.
+ */
+import type { RequestHandler } from 'msw';
+
+export const usersHandlers: RequestHandler[] = [];

--- a/client/src/test-utils/harness.spec.tsx
+++ b/client/src/test-utils/harness.spec.tsx
@@ -1,0 +1,54 @@
+/**
+ * Harness smoke test.
+ *
+ * This spec exists purely to prove the integration-test wiring boots:
+ * - Jest resolves and transforms a `.tsx` file.
+ * - jest-dom matchers are registered.
+ * - `renderWithProviders` mounts a trivial component without throwing.
+ * - The Clerk mock returns a configurable user object.
+ * - MSW is running (no unhandled-request errors are thrown).
+ *
+ * It can safely be deleted once real integration tests exist.
+ */
+import React from 'react';
+import { useUser } from '@clerk/clerk-react';
+
+import { renderWithProviders, screen } from './renderWithProviders';
+import { setTestUser } from './clerkMock';
+import { server } from './server';
+
+const RolesProbe: React.FC = () => {
+  const { user, isSignedIn } = useUser();
+  const roles = (user?.publicMetadata?.roles as string[] | undefined) ?? [];
+  return (
+    <div>
+      <span data-testid="signed-in">{String(isSignedIn)}</span>
+      <span data-testid="roles">{roles.join(',')}</span>
+      <span data-testid="email">{user?.primaryEmailAddress?.emailAddress ?? ''}</span>
+    </div>
+  );
+};
+
+describe('integration test harness', () => {
+  it('renders a component through the provider stack', () => {
+    renderWithProviders(<h1>harness ok</h1>);
+    expect(screen.getByRole('heading', { name: /harness ok/i })).toBeInTheDocument();
+  });
+
+  it('exposes a configurable Clerk mock user to hooks', () => {
+    setTestUser({ roles: ['Super Admin'], emailAddress: 'admin@example.com' });
+
+    renderWithProviders(<RolesProbe />);
+
+    expect(screen.getByTestId('signed-in')).toHaveTextContent('true');
+    expect(screen.getByTestId('roles')).toHaveTextContent('Super Admin');
+    expect(screen.getByTestId('email')).toHaveTextContent('admin@example.com');
+  });
+
+  it('has an MSW server instance ready for per-test handler overrides', () => {
+    // The shared server is constructed in `./server.ts`; exposing `.use` and
+    // `.resetHandlers` is enough to confirm it is the real msw/node instance.
+    expect(typeof server.use).toBe('function');
+    expect(typeof server.resetHandlers).toBe('function');
+  });
+});

--- a/client/src/test-utils/index.ts
+++ b/client/src/test-utils/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Public entry point for the integration test harness. Import from here in
+ * spec files so there's a single, discoverable surface for test utilities.
+ *
+ *   import { renderWithProviders, setTestUser, server } from '@/test-utils';
+ */
+export { renderWithProviders, createTestQueryClient } from './renderWithProviders';
+export { server } from './server';
+export { setTestUser, setSignedOut, resetClerkMock, getTestUser } from './clerkMock';
+export type { TestUser } from './clerkMock';

--- a/client/src/test-utils/jest.polyfills.ts
+++ b/client/src/test-utils/jest.polyfills.ts
@@ -1,0 +1,54 @@
+/**
+ * Early Jest polyfills that must run before any module that touches them
+ * (MSW v2, React 19, Clerk, etc.) is imported. Loaded via `setupFiles`
+ * so it executes before the test framework and before `setupTests.ts`.
+ *
+ * jsdom omits a number of globals that modern browser-targeted packages
+ * assume exist. Adding them here keeps individual tests free of boilerplate.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const globalAny = globalThis as any;
+
+// TextEncoder / TextDecoder — required by MSW v2 and several WHATWG
+// primitives polyfilled below. jsdom only ships these in newer versions.
+import { TextEncoder, TextDecoder } from 'util';
+
+if (typeof globalAny.TextEncoder === 'undefined') {
+  globalAny.TextEncoder = TextEncoder;
+}
+if (typeof globalAny.TextDecoder === 'undefined') {
+  globalAny.TextDecoder = TextDecoder;
+}
+
+// fetch / Request / Response / Headers — MSW v2 patches these, but the
+// underlying implementations must exist first. `whatwg-fetch` registers
+// browser-spec globals against `globalThis` when imported for side effects.
+import 'whatwg-fetch';
+
+// BroadcastChannel is used by MSW's internals in some environments; jsdom
+// does not implement it. A minimal no-op shim is enough for tests.
+if (typeof globalAny.BroadcastChannel === 'undefined') {
+  class BroadcastChannelShim {
+    name: string;
+    onmessage: ((ev: MessageEvent) => void) | null = null;
+    constructor(name: string) {
+      this.name = name;
+    }
+    postMessage(_message: unknown): void {}
+    close(): void {}
+    addEventListener(): void {}
+    removeEventListener(): void {}
+    dispatchEvent(): boolean {
+      return true;
+    }
+  }
+  globalAny.BroadcastChannel = BroadcastChannelShim;
+}
+
+// Default API base URL. Application code reads `import.meta.env.VITE_API_URL`,
+// but during tests we also expose it via process.env as a convenient default
+// that MSW handlers / axios base URL overrides can rely on.
+process.env.VITE_API_URL = process.env.VITE_API_URL ?? 'http://localhost';
+process.env.VITE_CLERK_PUBLISHABLE_KEY =
+  process.env.VITE_CLERK_PUBLISHABLE_KEY ?? 'pk_test_integration-tests';

--- a/client/src/test-utils/renderWithProviders.tsx
+++ b/client/src/test-utils/renderWithProviders.tsx
@@ -1,0 +1,84 @@
+/**
+ * `renderWithProviders` — the standard way to render a React tree inside
+ * integration tests. It wires up the same providers the real app uses so
+ * components behave as close to production as possible, while making sure
+ * each test gets isolated state.
+ *
+ * Providers wired, outer → inner:
+ *   1. MUI `ThemeProvider` (dark theme, stable across tests).
+ *   2. `QueryClientProvider` with a fresh `QueryClient` per render so React
+ *      Query caches never leak between tests.
+ *   3. `MemoryRouter` so components that rely on React Router work without
+ *      a real browser history.
+ *
+ * Clerk is intentionally NOT wrapped here — the `@clerk/clerk-react` module
+ * is mocked globally via `./clerkMock.ts`, so Clerk hooks resolve to the
+ * shared test fixtures regardless of where they are invoked in the tree.
+ */
+import React, { ReactElement, ReactNode } from 'react';
+import { render, RenderOptions, RenderResult } from '@testing-library/react';
+import { MemoryRouter, MemoryRouterProps } from 'react-router-dom';
+import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { darkTheme } from '../themes/darkTheme';
+
+// Importing the Clerk mock here guarantees the `jest.mock('@clerk/clerk-react', …)`
+// side effect is registered whenever a test uses `renderWithProviders`, even
+// if the test file forgets to import `setupTests.ts` directly.
+import './clerkMock';
+
+export interface RenderWithProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
+  /** Initial entries for the in-memory router. Defaults to `['/']`. */
+  routerProps?: MemoryRouterProps;
+  /** Pre-configured `QueryClient` — otherwise a fresh one is created per render. */
+  queryClient?: QueryClient;
+}
+
+/**
+ * Build a `QueryClient` tuned for tests:
+ * - no retries (failing API calls surface immediately)
+ * - no refetch-on-window-focus (jsdom triggers focus events unexpectedly)
+ * - silent logging so jest output stays readable
+ */
+export const createTestQueryClient = (): QueryClient =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        refetchOnWindowFocus: false,
+        gcTime: 0,
+        staleTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+export const renderWithProviders = (
+  ui: ReactElement,
+  options: RenderWithProvidersOptions = {},
+): RenderResult & { queryClient: QueryClient } => {
+  const { routerProps, queryClient, ...renderOptions } = options;
+  const client = queryClient ?? createTestQueryClient();
+
+  const Wrapper: React.FC<{ children: ReactNode }> = ({ children }) => (
+    <MuiThemeProvider theme={darkTheme}>
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/']} {...routerProps}>
+          {children}
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MuiThemeProvider>
+  );
+
+  return {
+    ...render(ui, { wrapper: Wrapper, ...renderOptions }),
+    queryClient: client,
+  };
+};
+
+// Re-export the Testing Library surface so tests can import everything from
+// one place (`import { renderWithProviders, screen } from '@/test-utils/renderWithProviders'`).
+export * from '@testing-library/react';

--- a/client/src/test-utils/server.ts
+++ b/client/src/test-utils/server.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared MSW server used by every integration test.
+ *
+ * The default handler set is intentionally empty; each module contributes
+ * its own handler folder under `./handlers/<module>` and re-exports the
+ * aggregate list from `./handlers/index.ts`. Tests can still append
+ * per-test overrides via `server.use(...)`.
+ */
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+export const server = setupServer(...handlers);

--- a/client/src/test-utils/setupTests.ts
+++ b/client/src/test-utils/setupTests.ts
@@ -1,0 +1,32 @@
+/**
+ * Global Jest setup that runs after the test framework is installed.
+ *
+ * - Extends `expect` with @testing-library/jest-dom matchers.
+ * - Boots the shared MSW server with the default (empty) handler set and
+ *   tears it down around each test file so request handlers do not leak
+ *   between suites.
+ * - Resets the Clerk mock user between tests so role-specific fixtures
+ *   don't bleed across suites.
+ */
+
+import '@testing-library/jest-dom';
+
+import { server } from './server';
+import { resetClerkMock } from './clerkMock';
+
+// Start MSW once per test process. `onUnhandledRequest: 'error'` is a
+// deliberate choice so a missing handler surfaces as a failing test instead
+// of a silent network pass-through.
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' });
+});
+
+// Reset between tests so one test's request override cannot influence the next.
+afterEach(() => {
+  server.resetHandlers();
+  resetClerkMock();
+});
+
+afterAll(() => {
+  server.close();
+});

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -23,5 +23,10 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/test-utils/**/*"
+  ]
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
   ]
 }

--- a/client/tsconfig.test.json
+++ b/client/tsconfig.test.json
@@ -1,0 +1,40 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    // ts-jest will transpile TS to CommonJS for Jest. The app's own tsconfig
+    // targets ESNext module output (bundler mode), so we override a few keys
+    // here to keep ts-jest happy without affecting the Vite build.
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "target": "ES2020",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "isolatedModules": true,
+    "noEmit": true,
+
+    // Tests often have intentionally unused params (mock signatures, etc.).
+    // Relax the app's strict "noUnused*" flags so test fixtures don't fight them.
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+
+    // `allowImportingTsExtensions` from the app config conflicts with the CJS
+    // emission Jest needs. Turn it off for the test project.
+    "allowImportingTsExtensions": false,
+
+    "types": ["jest", "node", "@testing-library/jest-dom"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/test-utils/**/*.ts",
+    "src/test-utils/**/*.tsx"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
Implementation of IA-456

Prepare integration tests setup

# Implementation Plan

## Conceptual Checklist
- Verify Jest/TS/React 19/ESM compatibility matrix.
- Add required dev dependencies (RTL, jsdom, MSW, user-event).
- Author jest.config + tsconfig for tests + setup files.
- Provide reusable harness: renderWithProviders, Clerk mocks, MSW server.
- Scaffold per-module MSW handler folders (empty-ready).
- Wire npm scripts + lint rules; do NOT add example tests (infra-only).

## Overview
Deliver infrastructure only for client-side integration tests: Jest 29 + jsdom + React Testing Library + MSW, with @clerk/clerk-react hooks mocked via jest.mock and configurable role fixtures. No backend, no Testcontainers, no sample tests beyond a single smoke test that proves the harness boots.

## Assumptions and Rules from CLAUDE.md
- Project CLAUDE.md: keep module-based layout under src/modules/*; React Query for server state; Clerk for auth; VITE_API_URL base URL. Test files follow *.spec.ts naming (root CLAUDE.md).
- Lint must pass (`npm run dev` runs ESLint first) — test files must be covered by eslint config or excluded.
- Jest config: `--passWithNoTests` preserved so CI stays green before tests exist.
- Ambiguity: folder convention (src/__tests__ vs src/test-utils). Resolution: put shared harness in `src/test-utils/` and co-locate future `*.spec.tsx` next to source, matching root CLAUDE.md naming.

## Step-by-Step Implementation
1. Install devDeps: `@testing-library/react@^16`, `@testing-library/jest-dom`, `@testing-library/user-event`, `jest-environment-jsdom`, `msw@^2`, `whatwg-fetch`, `identity-obj-proxy`.
- Files: client/package.json
2. Add `client/jest.config.ts` — preset ts-jest/ESM, testEnvironment jsdom, setupFilesAfterEach, moduleNameMapper for CSS/assets + `^@/(.*)$`, transformIgnorePatterns for MSW/Clerk ESM.
3. Add `client/tsconfig.test.json` extending app config with `types: ["jest","node","@testing-library/jest-dom"]`.
4. Create `src/test-utils/`:
- `setupTests.ts`: import jest-dom, start/stop MSW server, reset handlers.
- `server.ts`: `setupServer(...handlers)` from msw/node.
- `handlers/` with per-module sub-folders: tenants, users, secrets, invoices (index.ts re-exports empty arrays).
- `clerkMock.ts`: `jest.mock('@clerk/clerk-react', …)` factory with `setTestUser({ roles })` helper covering useUser, useAuth, SignedIn, SignedOut, ClerkProvider.
- `renderWithProviders.tsx`: wraps in QueryClientProvider (fresh per test), MUI ThemeProvider, MemoryRouter, MockedClerkProvider.
5. Update `package.json` scripts: keep `test`, add `test:watch`, `test:ci`. Ensure `VITE_API_URL` default in setup (e.g. http://localhost).
6. Add ESLint override for `*.spec.*` + test-utils (allow jest globals).
7. Add one smoke spec `src/test-utils/harness.spec.tsx` asserting renderWithProviders mounts a trivial component — proves wiring, then deletable.
8. Verify: `npm run lint && npm test` green.

## Error Handling and Uncertainties
- ts-jest ESM + React 19 can require `useESM: true` and `.js` extension mapping; mitigation: pin to ts-jest 29.3 config documented for ESM.
- MSW v2 requires Node 18+ and `TextEncoder` polyfill in jsdom; add polyfill in setupTests.
- Clerk hook shapes evolve; centralise mock so future Clerk bumps update one file.
- If team prefers Vitest later, harness is isolated under src/test-utils/ for easy migration.