### PR TITLE
IA-462 Resolve an issue with Export to Excel on the Invoice page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -192,25 +192,7 @@ export class InvoiceController {
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
         summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
-    })
-    @ApiQuery({
-        name: 'status',
-        required: false,
-        enum: ['PAID', 'UNPAID', 'OVERDUE'],
-        description: 'Filter invoices by status',
+        description: 'Exports all invoices for the tenant to an Excel file, regardless of pagination or filters',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -221,10 +203,9 @@ export class InvoiceController {
     async exportToExcel(
         @Req() request: RequestWithTenant,
         @Res() response: Response,
-        @Query() paginationParams: PaginationParamsDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        const buffer = await this.invoiceService.exportToExcel(tenantId);
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -1,6 +1,5 @@
 import { InvoiceDto } from '../dto/invoice.dto';
-import { PaginatedResponseDto } from '../dto/pagination.dto';
-import { PaginationParamsDto } from '../dto/pagination.dto';
+import { PaginatedResponseDto, PaginationParamsDto } from '../dto/pagination.dto';
 
 export const INVOICE_SERVICE = 'INVOICE_SERVICE';
 
@@ -16,7 +15,7 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    exportToExcel(tenantId: string): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -104,11 +104,9 @@ export class InvoiceService implements IInvoiceService {
         await this.invoiceRepository.remove(id, tenantId);
     }
 
-    async exportToExcel(
-        tenantId: string,
-        paginationParams: PaginationParamsDto,
-    ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+    async exportToExcel(tenantId: string): Promise<Buffer> {
+        // Fetch all invoices without pagination so the export is never page-bounded
+        const invoices = await this.invoiceRepository.findAllForExport(tenantId);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -41,6 +41,18 @@ export class InvoiceRepository {
         });
     }
 
+    /**
+     * Fetches all invoices for a tenant without pagination or status filtering.
+     * Used exclusively by the export flow to ensure every invoice is included
+     * regardless of the user's current page/filter state.
+     */
+    async findAllForExport(tenantId: string): Promise<Invoice[]> {
+        return this.invoiceRepository.find({
+            where: { tenantId, isArchived: false },
+            order: { issueDate: 'DESC' },
+        });
+    }
+
     async findById(id: string, tenantId: string): Promise<Invoice | null> {
         return this.invoiceRepository.findOne({
             where: { id, tenantId },

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -258,11 +258,11 @@ const InvoiceManagementPage: React.FC = () => {
     setPage(1); // Reset to first page when changing limit
   };
 
-  // Handle export to Excel
+  // Handle export to Excel — exports ALL invoices regardless of current page/filter state
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      const blob = await invoiceService.exportInvoices();
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,23 +80,13 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
-   * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * Export all invoices to Excel file.
+   * No pagination or filtering parameters are sent so the backend
+   * returns every invoice for the tenant in a single file.
    * @returns Promise<Blob>
    */
-  exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
-    status?: string,
-  ): Promise<Blob> => {
+  exportInvoices: async (): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
-      params: {
-        page,
-        limit,
-        ...(status && { status }),
-      },
       responseType: 'blob',
     });
     return response.data;


### PR DESCRIPTION
Implementation of IA-462

Currently, when a user tries to export invoices, only the invoices visible on a page are exported.
Expected result: all invoices, regardless of pagination and filtering, must be exported

# Implementation Plan

## Conceptual Checklist
- Understand the 3-layer export flow (frontend handler → frontend service → backend controller → service → repository)
- Determine what 'regardless of filtering' means for the export
- Modify backend to support unpaginated, unfiltered export
- Modify frontend to stop passing pagination/filter params to export
- Ensure memory safety for large datasets (streaming or buffering)
- Follow clean architecture: dependencies point inward

## Overview
Remove pagination and filtering constraints from the invoice export flow so that all invoices for a tenant are exported to Excel regardless of the user's current view state.

## Assumptions and Rules from CLAUDE.md
- Clean architecture: API → Application → Domain (no business logic in infrastructure/presentation)
- Repository pattern for data access
- TypeORM for database operations
- DTOs for data transfer between layers
- ESLint enforced before dev servers start; run `npm run lint` to verify

## Step-by-Step Implementation

1. **Backend Repository** (`api/src/application/repositories/invoice.repository.ts`)
- Add a new method `findAllForExport(tenantId: string)` that queries all invoices without `skip`/`take` pagination and without status/archived filters
- Keep existing `findAll` untouched for the list endpoint

2. **Backend Service Interface** (`api/src/application/invoices/interfaces/invoice.service.interface.ts`)
- Update `exportToExcel` signature to only require `tenantId` (remove `PaginationParamsDto`)

3. **Backend Service** (`api/src/application/invoices/invoice.service.ts`)
- Update `exportToExcel` to call `findAllForExport(tenantId)` instead of `findAll(tenantId, paginationParams)`

4. **Backend Controller** (`api/src/api/controllers/invoice.controller.ts`)
- Remove `@Query() paginationParams` from the `exportToExcel` endpoint
- Pass only `tenantId` to the service

5. **Frontend Service** (`client/src/modules/invoices/services/invoiceService.ts`)
- Simplify `exportInvoices` to not send `page`, `limit`, or `status` params

6. **Frontend Handler** (`client/src/modules/invoices/components/InvoiceManagementPage.tsx`)
- Update `handleExportToExcel` to call `exportInvoices()` with no arguments

7. **Verify** — Run `npm run lint` in both `api/` and `client/` directories

## Error Handling and Uncertainties
- **Large dataset concern**: If a tenant has thousands of invoices, generating a single XLSX in memory could be expensive. Mitigation: exceljs supports streaming, but for MVP this should be acceptable.
- **Filtering ambiguity**: Task says 'regardless of filtering' — assumed to mean export all invoices. If the intent is to keep filters but remove pagination, the repository method should accept optional filter params instead.