### PR TITLE
IA-465 Fix invoices CSV export to include all matching records, not just the current page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -33,6 +33,7 @@ import {
 } from '@nestjs/swagger';
 import { InvoiceDto } from '../../application/invoices/dto/invoice.dto';
 import {
+    ExportInvoicesParamsDto,
     PaginatedResponseDto,
     PaginationParamsDto,
 } from '../../application/invoices/dto/pagination.dto';
@@ -192,25 +193,39 @@ export class InvoiceController {
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
         summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
+        description:
+            'Exports ALL invoices matching the active filters to an Excel file. ' +
+            'Pagination is bypassed — every matching record is included regardless of page/limit.',
     })
     @ApiQuery({
         name: 'status',
         required: false,
         enum: ['PAID', 'UNPAID', 'OVERDUE'],
-        description: 'Filter invoices by status',
+        description: 'Filter exported invoices by status',
+    })
+    @ApiQuery({
+        name: 'includeArchived',
+        required: false,
+        type: Boolean,
+        description: 'Include archived invoices in the export',
+    })
+    @ApiQuery({
+        name: 'search',
+        required: false,
+        type: String,
+        description: 'Search term to filter by vendor or customer name (case-insensitive)',
+    })
+    @ApiQuery({
+        name: 'dateFrom',
+        required: false,
+        type: String,
+        description: 'Start of date range filter (YYYY-MM-DD)',
+    })
+    @ApiQuery({
+        name: 'dateTo',
+        required: false,
+        type: String,
+        description: 'End of date range filter (YYYY-MM-DD)',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -221,10 +236,10 @@ export class InvoiceController {
     async exportToExcel(
         @Req() request: RequestWithTenant,
         @Res() response: Response,
-        @Query() paginationParams: PaginationParamsDto,
+        @Query() exportParams: ExportInvoicesParamsDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        const buffer = await this.invoiceService.exportToExcel(tenantId, exportParams);
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/dto/pagination.dto.ts
+++ b/api/src/application/invoices/dto/pagination.dto.ts
@@ -50,6 +50,62 @@ export class PaginationParamsDto {
     includeArchived?: boolean = false;
 }
 
+/**
+ * DTO for export-specific query parameters.
+ * Unlike PaginationParamsDto, this does not include page/limit fields —
+ * exports always return all matching records regardless of pagination.
+ */
+export class ExportInvoicesParamsDto {
+    @ApiProperty({
+        description: 'Filter exported invoices by status',
+        example: 'PAID',
+        enum: ['PAID', 'UNPAID', 'OVERDUE'],
+        required: false,
+    })
+    @IsString()
+    @IsIn(['PAID', 'UNPAID', 'OVERDUE'])
+    @IsOptional()
+    status?: string;
+
+    @ApiProperty({
+        description: 'Include archived invoices in the export',
+        example: false,
+        default: false,
+        required: false,
+    })
+    @IsBoolean()
+    @IsOptional()
+    @Transform(({ value }) => value === 'true' || value === true)
+    includeArchived?: boolean = false;
+
+    @ApiProperty({
+        description: 'Search term to filter by vendor name or customer name (case-insensitive)',
+        example: 'Acme Corp',
+        required: false,
+    })
+    @IsString()
+    @IsOptional()
+    search?: string;
+
+    @ApiProperty({
+        description: 'Start date for date range filter (YYYY-MM-DD). Matches invoices whose issueDate or dueDate falls within [dateFrom, dateTo].',
+        example: '2024-01-01',
+        required: false,
+    })
+    @IsString()
+    @IsOptional()
+    dateFrom?: string;
+
+    @ApiProperty({
+        description: 'End date for date range filter (YYYY-MM-DD). Matches invoices whose issueDate or dueDate falls within [dateFrom, dateTo].',
+        example: '2024-12-31',
+        required: false,
+    })
+    @IsString()
+    @IsOptional()
+    dateTo?: string;
+}
+
 export class PaginatedResponseDto<T> {
     @ApiProperty({
         description: 'Array of items for the current page',

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -1,6 +1,5 @@
 import { InvoiceDto } from '../dto/invoice.dto';
-import { PaginatedResponseDto } from '../dto/pagination.dto';
-import { PaginationParamsDto } from '../dto/pagination.dto';
+import { ExportInvoicesParamsDto, PaginatedResponseDto, PaginationParamsDto } from '../dto/pagination.dto';
 
 export const INVOICE_SERVICE = 'INVOICE_SERVICE';
 
@@ -16,7 +15,11 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    /**
+     * Exports all invoices matching the given filters to an Excel buffer.
+     * Pagination is deliberately bypassed — all matching records are included.
+     */
+    exportToExcel(tenantId: string, exportParams: ExportInvoicesParamsDto): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -4,7 +4,7 @@ import { IInvoiceService } from './interfaces/invoice.service.interface';
 import { InvoiceRepository } from '../repositories/invoice.repository';
 import { InvoiceMapper } from './invoice.mapper';
 import { InvoiceDto } from './dto/invoice.dto';
-import { PaginatedResponseDto, PaginationParamsDto } from './dto/pagination.dto';
+import { ExportInvoicesParamsDto, PaginatedResponseDto, PaginationParamsDto } from './dto/pagination.dto';
 import { Invoice } from '../../domain/entities/invoice.entity';
 import { InvoiceItem } from '../../domain/entities/invoice-item.entity';
 
@@ -106,9 +106,10 @@ export class InvoiceService implements IInvoiceService {
 
     async exportToExcel(
         tenantId: string,
-        paginationParams: PaginationParamsDto,
+        exportParams: ExportInvoicesParamsDto,
     ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+        // Fetch ALL records matching the active filters — pagination is intentionally bypassed
+        const invoices = await this.invoiceRepository.findAllForExport(tenantId, exportParams);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Invoice } from '../../domain/entities/invoice.entity';
-import { PaginationParamsDto } from '../invoices/dto/pagination.dto';
+import { ExportInvoicesParamsDto, PaginationParamsDto } from '../invoices/dto/pagination.dto';
 import { AnalyticsFiltersDto } from '../analytics/dto/analytics-filters.dto';
 
 @Injectable()
@@ -39,6 +39,76 @@ export class InvoiceRepository {
                 issueDate: 'DESC',
             },
         });
+    }
+
+    /**
+     * Retrieves all invoices matching the given export filters without any pagination.
+     * Intended exclusively for the export flow — pagination must not limit export results.
+     *
+     * @param tenantId - The tenant to scope the query to
+     * @param exportParams - Optional filters: status, includeArchived, search (vendor/customer name), dateFrom, dateTo
+     * @returns All matching Invoice records ordered by issueDate DESC
+     */
+    async findAllForExport(
+        tenantId: string,
+        exportParams: ExportInvoicesParamsDto,
+    ): Promise<Invoice[]> {
+        const query = this.invoiceRepository
+            .createQueryBuilder('invoice')
+            .where('invoice.tenantId = :tenantId', { tenantId })
+            .orderBy('invoice.issueDate', 'DESC');
+
+        // By default, exclude archived invoices unless explicitly requested
+        if (!exportParams.includeArchived) {
+            query.andWhere('invoice.isArchived = :isArchived', { isArchived: false });
+        }
+
+        // Optional status filter
+        if (exportParams.status) {
+            query.andWhere('invoice.status = :status', { status: exportParams.status });
+        }
+
+        // Optional text search across vendor name and customer name (case-insensitive)
+        if (exportParams.search) {
+            query.andWhere(
+                '(LOWER(invoice.vendorName) LIKE :search OR LOWER(invoice.customerName) LIKE :search)',
+                { search: `%${exportParams.search.toLowerCase()}%` },
+            );
+        }
+
+        // Optional date range — match invoices whose issueDate or dueDate falls within [dateFrom, dateTo]
+        if (exportParams.dateFrom || exportParams.dateTo) {
+            const conditions: string[] = [];
+            const params: Record<string, string> = {};
+
+            if (exportParams.dateFrom) {
+                params.dateFrom = exportParams.dateFrom;
+            }
+            if (exportParams.dateTo) {
+                params.dateTo = exportParams.dateTo;
+            }
+
+            if (exportParams.dateFrom && exportParams.dateTo) {
+                conditions.push(
+                    '(invoice.issueDate >= :dateFrom AND invoice.issueDate <= :dateTo)',
+                    '(invoice.dueDate >= :dateFrom AND invoice.dueDate <= :dateTo)',
+                );
+            } else if (exportParams.dateFrom) {
+                conditions.push(
+                    'invoice.issueDate >= :dateFrom',
+                    'invoice.dueDate >= :dateFrom',
+                );
+            } else if (exportParams.dateTo) {
+                conditions.push(
+                    'invoice.issueDate <= :dateTo',
+                    'invoice.dueDate <= :dateTo',
+                );
+            }
+
+            query.andWhere(`(${conditions.join(' OR ')})`, params);
+        }
+
+        return query.getMany();
     }
 
     async findById(id: string, tenantId: string): Promise<Invoice | null> {

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -259,10 +259,27 @@ const InvoiceManagementPage: React.FC = () => {
   };
 
   // Handle export to Excel
+  // All active filters are forwarded to the server so the export reflects exactly
+  // what the user is currently viewing — but without any page/limit restriction.
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      // Convert the ±7-day date picker value to an explicit [dateFrom, dateTo] range
+      // that the server can use for filtering, mirroring the client-side logic.
+      let dateFrom: string | undefined;
+      let dateTo: string | undefined;
+      if (dateFilter) {
+        dateFrom = dateFilter.subtract(7, 'day').format('YYYY-MM-DD');
+        dateTo = dateFilter.add(7, 'day').format('YYYY-MM-DD');
+      }
+
+      const blob = await invoiceService.exportInvoices({
+        status: statusFilter || undefined,
+        includeArchived,
+        search: searchQuery || undefined,
+        dateFrom,
+        dateTo,
+      });
 
       // Create download link
       const url = window.URL.createObjectURL(blob);
@@ -277,6 +294,7 @@ const InvoiceManagementPage: React.FC = () => {
       window.URL.revokeObjectURL(url);
     } catch (error) {
       console.error('Error exporting invoices:', error);
+      enqueueSnackbar('Failed to export invoices. Please try again.', { variant: 'error' });
     } finally {
       setIsExporting(false);
     }

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,22 +80,36 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
+   * Export all invoices matching the active filters to an Excel file.
+   * Pagination is bypassed server-side — every matching record is included.
+   *
    * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * @param includeArchived - Include archived invoices in the export (default: false)
+   * @param search - Optional search term for vendor or customer name
+   * @param dateFrom - Optional start of date range (YYYY-MM-DD)
+   * @param dateTo - Optional end of date range (YYYY-MM-DD)
    * @returns Promise<Blob>
    */
-  exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
-    status?: string,
-  ): Promise<Blob> => {
+  exportInvoices: async ({
+    status,
+    includeArchived = false,
+    search,
+    dateFrom,
+    dateTo,
+  }: {
+    status?: string;
+    includeArchived?: boolean;
+    search?: string;
+    dateFrom?: string;
+    dateTo?: string;
+  } = {}): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
       params: {
-        page,
-        limit,
         ...(status && { status }),
+        includeArchived,
+        ...(search && { search }),
+        ...(dateFrom && { dateFrom }),
+        ...(dateTo && { dateTo }),
       },
       responseType: 'blob',
     });


### PR DESCRIPTION
Implementation of IA-465

SummaryThe CSV/Excel export on the invoices screen currently exports only the records visible on the current page. Users who have hundreds or thousands of invoices must manually page through and export each page separately, which is error-prone and time-consuming..
What needs to changeThe export action on the invoices view must retrieve all records that match the user's active search and filter selections, regardless of which page the user is currently viewing. Pagination should only affect the on-screen table display — it must not limit the exported dataset.
Expected behaviour after the fixA user viewing a filtered list of 500 invoices across 10 pages clicks "Export to CSV" and receives a single file containing all 500 invoices.
A user with no filters applied exports the entire invoices dataset in one file.
There is no hard cap on the number of records in the export.
NotesActive search terms and filter selections must still be respected in the export — only pagination should be bypassed.
Consider the performance impact of very large exports and ensure the user receives clear feedback (e.g., a loading indicator) while the file is being generated.

# Implementation Plan

## Conceptual Checklist

- Identify all files involved in the export flow (controller, service, repository, frontend service, UI component)
- Determine how to bypass pagination while preserving filters
- Add server-side search/date filtering to support full-fidelity export
- Ensure loading feedback during large exports
- Follow clean architecture: dependencies point inward, DTOs for data transfer
- Test with large datasets for performance

## Overview

Modify the invoice export flow to retrieve ALL records matching active filters (status, archived, search, date) without pagination. Changes span backend (repository, service, controller, DTOs) and frontend (service, management page).

## Assumptions and Rules from CLAUDE.md

- Clean architecture: API → Application → Domain (no business logic in controller)
- DTOs for data transfer between layers
- Repository pattern for data access
- TypeORM for DB operations
- `exceljs` already in use for Excel generation
- ESLint enforced before dev server start

## Step-by-Step Implementation

1. **Create `ExportParamsDto`** in `api/src/application/invoices/dto/pagination.dto.ts`
- Fields: `status?`, `includeArchived?`, `search?`, `dateFrom?`, `dateTo?`
- No `page`/`limit` fields
- Dependencies: None

2. **Add `findAllForExport()` to `InvoiceRepository`** (`api/src/application/repositories/invoice.repository.ts`)
- Accepts `ExportParamsDto` + `tenantId`
- Builds WHERE clause: tenantId, status, isArchived, optional ILIKE on vendorName/customerName, optional date range on issueDate
- No `skip`/`take` — returns all matching records
- Orders by `issueDate DESC`

3. **Update `IInvoiceService` interface** (`api/src/application/invoices/interfaces/invoice.service.interface.ts`)
- Change `exportToExcel` signature to accept `ExportParamsDto` instead of `PaginationParamsDto`

4. **Update `InvoiceService.exportToExcel()`** (`api/src/application/invoices/invoice.service.ts`)
- Call `findAllForExport()` instead of `findAll()`
- Remove pagination logic from export path

5. **Update export controller endpoint** (`api/src/api/controllers/invoice.controller.ts`)
- Change `@Query()` param type to `ExportParamsDto`
- Pass new DTO to service

6. **Update `invoiceService.exportInvoices()`** on frontend (`client/src/modules/invoices/services/invoiceService.ts`)
- Change params: remove `page`/`limit`, add `status?`, `includeArchived?`, `search?`, `dateFrom?`, `dateTo?`

7. **Update `handleExportToExcel()`** in `InvoiceManagementPage.tsx`
- Pass all active filters (statusFilter, includeArchived, searchQuery, dateFilter converted to dateFrom/dateTo) instead of page/limit
- Loading indicator already exists via `isExporting` state

## Error Handling and Uncertainties

- **Large dataset performance**: Very large exports could cause memory pressure with `exceljs` buffering. Mitigation: monitor, consider streaming in future.
- **Client-side search mismatch**: If server-side ILIKE search doesn't exactly match the client-side JS `.includes()` behavior, minor discrepancies could occur. Mitigation: use case-insensitive ILIKE matching.
- **Date filter scope**: Client currently uses ±7 day range around selected date. Must replicate this logic when computing dateFrom/dateTo params.