### PR TITLE
IA-472 Resolve issue with export to Excel on invoices page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -192,25 +192,7 @@ export class InvoiceController {
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
         summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
-    })
-    @ApiQuery({
-        name: 'status',
-        required: false,
-        enum: ['PAID', 'UNPAID', 'OVERDUE'],
-        description: 'Filter invoices by status',
+        description: 'Exports all non-archived invoices for the tenant to an Excel file',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -221,10 +203,9 @@ export class InvoiceController {
     async exportToExcel(
         @Req() request: RequestWithTenant,
         @Res() response: Response,
-        @Query() paginationParams: PaginationParamsDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        const buffer = await this.invoiceService.exportToExcel(tenantId);
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -16,7 +16,7 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    exportToExcel(tenantId: string): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -104,11 +104,8 @@ export class InvoiceService implements IInvoiceService {
         await this.invoiceRepository.remove(id, tenantId);
     }
 
-    async exportToExcel(
-        tenantId: string,
-        paginationParams: PaginationParamsDto,
-    ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+    async exportToExcel(tenantId: string): Promise<Buffer> {
+        const invoices = await this.invoiceRepository.findAllForExport(tenantId);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -41,6 +41,17 @@ export class InvoiceRepository {
         });
     }
 
+    /**
+     * Fetches all non-archived invoices for a tenant without pagination,
+     * intended for use in export operations.
+     */
+    async findAllForExport(tenantId: string): Promise<Invoice[]> {
+        return this.invoiceRepository.find({
+            where: { tenantId, isArchived: false },
+            order: { issueDate: 'DESC' },
+        });
+    }
+
     async findById(id: string, tenantId: string): Promise<Invoice | null> {
         return this.invoiceRepository.findOne({
             where: { id, tenantId },

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -258,11 +258,11 @@ const InvoiceManagementPage: React.FC = () => {
     setPage(1); // Reset to first page when changing limit
   };
 
-  // Handle export to Excel
+  // Handle export to Excel - exports all non-archived invoices regardless of current page/filter
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      const blob = await invoiceService.exportInvoices();
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,23 +80,11 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
-   * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * Export all non-archived invoices for the current tenant to an Excel file.
    * @returns Promise<Blob>
    */
-  exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
-    status?: string,
-  ): Promise<Blob> => {
+  exportInvoices: async (): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
-      params: {
-        page,
-        limit,
-        ...(status && { status }),
-      },
       responseType: 'blob',
     });
     return response.data;


### PR DESCRIPTION
Implementation of IA-472

Resolve issue with export to Excel on invoices page

# Implementation Plan

## Conceptual Checklist

- Identify all layers that enforce pagination on export (repository, service, controller, client service, UI handler)
- Add a repository method to fetch all invoices without pagination
- Update the service's exportToExcel to use the unpaginated query
- Update the controller endpoint to not require pagination params for export
- Update the client service and UI handler to call export without page/limit/status
- Ensure tenant isolation is preserved
- Verify no performance concerns with eager-loaded items relation

## Overview

Remove pagination constraints from the invoice Excel export flow so that all invoices for the tenant are exported, regardless of current page, limit, or status filter.

## Assumptions and Rules from CLAUDE.md

- Dependencies point inward: API → Application → Domain (project CLAUDE.md)
- Repository pattern for data access (project CLAUDE.md)
- DTOs for data transfer between layers (project CLAUDE.md)
- ESLint runs before dev server; use `npm run lint:fix` to fix issues (project CLAUDE.md)
- Assumption: Archived invoices remain excluded by default

## Step-by-Step Implementation

1. **Add `findAllForExport` method to `InvoiceRepository`**
- File: `api/src/application/repositories/invoice.repository.ts`
- New method fetches all non-archived invoices for a tenant without skip/take, ordered by issueDate DESC

2. **Update `InvoiceService.exportToExcel`**
- File: `api/src/application/invoices/invoice.service.ts`
- Change signature to `exportToExcel(tenantId: string): Promise`
- Call `this.invoiceRepository.findAllForExport(tenantId)` instead of `findAll`

3. **Update `IInvoiceService` interface**
- File: `api/src/application/invoices/interfaces/invoice.service.interface.ts`
- Update `exportToExcel` signature to remove `paginationParams`

4. **Update `InvoiceController.exportToExcel`**
- File: `api/src/api/controllers/invoice.controller.ts`
- Remove `@Query() paginationParams` from the export endpoint
- Call `this.invoiceService.exportToExcel(tenantId)` without params
- Update Swagger decorators to remove page/limit/status ApiQuery

5. **Update client `invoiceService.exportInvoices`**
- File: `client/src/modules/invoices/services/invoiceService.ts`
- Remove page, limit, status parameters; call `/invoices/export/excel` with no query params

6. **Update `handleExportToExcel` in UI**
- File: `client/src/modules/invoices/components/InvoiceManagementPage.tsx`
- Call `invoiceService.exportInvoices()` with no arguments

## Error Handling and Uncertainties

- **Large dataset performance**: With `eager: true` on invoice items, exporting thousands of invoices loads all line items. Consider whether items are needed for export (currently they aren't used in the Excel output — only invoice-level fields). Could optimize by not loading items relation.
- **Route ordering**: `GET export/excel` is after `GET :id` which could cause NestJS to match 'export' as an `:id`. This is a pre-existing issue but worth noting.
- **Memory**: Very large exports could strain server memory. For now, acceptable given typical invoice volumes.