### PR TITLE
IA-478 add new theme

### DIFF
--- a/client/src/themes/ThemeContext.tsx
+++ b/client/src/themes/ThemeContext.tsx
@@ -3,8 +3,9 @@ import { ThemeProvider as MuiThemeProvider, Theme } from '@mui/material';
 import { darkTheme } from './darkTheme';
 import { pinkGreyTheme } from './pinkGreyTheme';
 import { charcoalCitrusTheme } from './charcoalCitrusTheme';
+import { oceanDeepTheme } from './oceanDeepTheme';
 
-type ThemeMode = 'dark' | 'pinkGrey' | 'charcoalCitrus';
+type ThemeMode = 'dark' | 'pinkGrey' | 'charcoalCitrus' | 'oceanDeep';
 
 interface ThemeInfo {
   theme: Theme;
@@ -29,7 +30,7 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     // Load theme preference from localStorage
     try {
       const stored = localStorage.getItem(THEME_STORAGE_KEY);
-      if (stored === 'pinkGrey' || stored === 'charcoalCitrus') {
+      if (stored === 'pinkGrey' || stored === 'charcoalCitrus' || stored === 'oceanDeep') {
         return stored as ThemeMode;
       }
       return 'dark';
@@ -51,6 +52,12 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
           displayName: '🍋 Charcoal Citrus',
           iconColor: '#FF8C00', // Orange icon
         };
+      case 'oceanDeep':
+        return {
+          theme: oceanDeepTheme,
+          displayName: '🌊 Ocean Deep',
+          iconColor: '#4FC3F7', // Ocean blue icon
+        };
       case 'dark':
       default:
         return {
@@ -70,6 +77,8 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         newMode = 'pinkGrey';
       } else if (prev === 'pinkGrey') {
         newMode = 'charcoalCitrus';
+      } else if (prev === 'charcoalCitrus') {
+        newMode = 'oceanDeep';
       } else {
         newMode = 'dark';
       }

--- a/client/src/themes/index.ts
+++ b/client/src/themes/index.ts
@@ -1,8 +1,9 @@
 import { darkTheme } from './darkTheme';
 import { pinkGreyTheme } from './pinkGreyTheme';
 import { charcoalCitrusTheme } from './charcoalCitrusTheme';
+import { oceanDeepTheme } from './oceanDeepTheme';
 
 // Export the dark theme as the default theme
 export const theme = darkTheme;
 
-export { darkTheme, pinkGreyTheme, charcoalCitrusTheme };
+export { darkTheme, pinkGreyTheme, charcoalCitrusTheme, oceanDeepTheme };

--- a/client/src/themes/oceanDeepTheme.ts
+++ b/client/src/themes/oceanDeepTheme.ts
@@ -1,0 +1,197 @@
+import { createTheme } from '@mui/material';
+import { darken, lighten } from '@mui/material/styles';
+
+// Ocean Deep Theme - Ocean Blue/Teal on Dark Navy backgrounds
+export const oceanDeepTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#4FC3F7', // Ocean Blue (MUI light-blue 300)
+      light: lighten('#4FC3F7', 0.1),
+      dark: darken('#4FC3F7', 0.15),
+      contrastText: '#000000',
+    },
+    secondary: {
+      main: '#9CA3AF',
+      light: '#D1D5DB',
+      dark: '#6B7280',
+      contrastText: '#000000',
+    },
+    background: {
+      default: '#0A1929', // Dark Navy
+      paper: '#132F4C', // Slightly lighter navy for cards
+    },
+    text: {
+      primary: '#FFFFFF',
+      secondary: '#B3C5D7',
+    },
+    error: {
+      main: '#F87171',
+    },
+    warning: {
+      main: '#FBBF24',
+    },
+    info: {
+      main: '#60A5FA',
+    },
+    success: {
+      main: '#34D399',
+    },
+    invoiceStatus: {
+      paid: lighten('#4FC3F7', 0.1), // Lighter ocean blue for paid
+      unpaid: '#4FC3F7', // Ocean blue for unpaid
+      overdue: darken('#4FC3F7', 0.3), // Darker ocean blue for overdue
+    },
+    divider: 'rgba(79, 195, 247, 0.12)',
+  },
+  typography: {
+    fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+    h1: {
+      fontWeight: 700,
+    },
+    h2: {
+      fontWeight: 700,
+    },
+    h3: {
+      fontWeight: 600,
+    },
+    h4: {
+      fontWeight: 600,
+    },
+    h5: {
+      fontWeight: 600,
+    },
+    h6: {
+      fontWeight: 600,
+    },
+    button: {
+      fontWeight: 600,
+      textTransform: 'none',
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          boxShadow: '0 1px 2px rgba(0, 0, 0, 0.25)',
+          padding: '8px 16px',
+          transition: 'all 0.2s ease',
+          '&:hover': {
+            boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+            transform: 'translateY(-1px)',
+          },
+        },
+        contained: {
+          backgroundColor: '#4FC3F7',
+          color: '#000000',
+          '&:hover': {
+            backgroundColor: darken('#4FC3F7', 0.15),
+          },
+        },
+        outlined: {
+          borderColor: lighten('#4FC3F7', 0.1),
+          color: '#4FC3F7',
+          '&:hover': {
+            borderColor: '#4FC3F7',
+            backgroundColor: 'rgba(79, 195, 247, 0.08)',
+          },
+        },
+      },
+    },
+    MuiSelect: {
+      styleOverrides: {
+        root: {
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#4FC3F7',
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: 'rgba(255, 255, 255, 0.23)',
+          },
+        },
+      },
+    },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          '&.Mui-selected': {
+            backgroundColor: 'rgba(79, 195, 247, 0.16)',
+          },
+          '&.Mui-selected:hover': {
+            backgroundColor: 'rgba(79, 195, 247, 0.24)',
+          },
+          '&:hover': {
+            backgroundColor: 'rgba(255, 255, 255, 0.08)',
+          },
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.5), 0 1px 2px rgba(0, 0, 0, 0.3)',
+          border: '1px solid rgba(79, 195, 247, 0.12)',
+          backgroundImage: 'none',
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.5), 0 1px 2px rgba(0, 0, 0, 0.3)',
+        },
+      },
+    },
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.5)',
+          backgroundImage: 'none',
+          backgroundColor: '#132F4C',
+          borderBottom: '1px solid rgba(79, 195, 247, 0.12)',
+        },
+      },
+    },
+    MuiTableHead: {
+      styleOverrides: {
+        root: {
+          '& .MuiTableCell-root': {
+            fontWeight: 600,
+            color: '#FFFFFF',
+            backgroundColor: '#132F4C',
+            borderBottom: '2px solid rgba(79, 195, 247, 0.12)',
+          },
+        },
+      },
+    },
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '& fieldset': {
+              borderColor: 'rgba(255, 255, 255, 0.23)',
+            },
+            '&:hover fieldset': {
+              borderColor: 'rgba(255, 255, 255, 0.4)',
+            },
+            '&.Mui-focused fieldset': {
+              borderColor: '#4FC3F7',
+            },
+          },
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          fontWeight: 500,
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
Implementation of IA-478

add new theme

# Implementation Plan

## Conceptual Checklist

- Review existing theme file structure as template (charcoalCitrusTheme.ts)
- Define ocean blue/teal color palette on dark navy backgrounds
- Create new theme file following exact same structure
- Register theme in ThemeContext (type, getThemeInfo, toggleTheme cycle, localStorage)
- Export from index.ts barrel file
- Verify no linting issues

## Overview

Add a new 'oceanDeep' theme to the client app with an ocean blue/teal primary color on dark navy backgrounds, following the established MUI theme pattern.

## Assumptions and Rules from CLAUDE.md

- Follow existing theme file structure exactly (createTheme with palette, typography, shape, components)
- All themes use `mode: 'dark'` - maintain this convention
- Include custom `invoiceStatus` palette extension
- Use `darken`/`lighten` helpers from MUI for variants
- Run `npm run lint` after changes (CLAUDE.md: linting enforced)
- Theme toggle cycles through all themes sequentially

## Step-by-Step Implementation

1. Create `client/src/themes/oceanDeepTheme.ts`
- Primary: `#4FC3F7` (ocean blue) with lighten/darken variants
- Background: `#0A1929` (dark navy) / paper: `#132F4C`
- Same secondary, error, warning, info, success colors as other themes
- invoiceStatus using blue variants
- Full component overrides matching the pattern
- Files: `client/src/themes/oceanDeepTheme.ts`

2. Update `client/src/themes/ThemeContext.tsx`
- Import oceanDeepTheme
- Add `'oceanDeep'` to ThemeMode union type
- Add case in getThemeInfo with displayName and optional iconColor
- Update toggleTheme cycle: charcoalCitrus → oceanDeep → dark
- Update localStorage validation to accept 'oceanDeep'
- Files: `client/src/themes/ThemeContext.tsx`

3. Update `client/src/themes/index.ts`
- Import and export oceanDeepTheme
- Files: `client/src/themes/index.ts`

4. Run linting
- Command: `cd client && npm run lint`

## Error Handling and Uncertainties

- Exact blue hex values are a design judgment; using MUI blue palette-inspired `#4FC3F7` (light blue 300) which fits 'ocean' aesthetic
- The ThemeToggle component in invoices has hardcoded tooltip text mentioning only 2 themes - may need update but is not blocking