### PR TITLE
IA-486 Resolve an issue with Export to Excel on the Invocie page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -35,6 +35,7 @@ import { InvoiceDto } from '../../application/invoices/dto/invoice.dto';
 import {
     PaginatedResponseDto,
     PaginationParamsDto,
+    ExportFiltersDto,
 } from '../../application/invoices/dto/pagination.dto';
 import { Authorize } from '../../infrastructure/auth/decorators/authorize.decorator';
 import { RoleName } from '../../domain/enums/role-name.enum';
@@ -192,25 +193,19 @@ export class InvoiceController {
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
         summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
+        description: 'Exports ALL invoices to an Excel file (no pagination — every matching invoice is included). Use the optional status and includeArchived filters to narrow the result set.',
     })
     @ApiQuery({
         name: 'status',
         required: false,
         enum: ['PAID', 'UNPAID', 'OVERDUE'],
-        description: 'Filter invoices by status',
+        description: 'Filter exported invoices by status',
+    })
+    @ApiQuery({
+        name: 'includeArchived',
+        required: false,
+        type: Boolean,
+        description: 'Include archived invoices in the export (default: false)',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -221,10 +216,10 @@ export class InvoiceController {
     async exportToExcel(
         @Req() request: RequestWithTenant,
         @Res() response: Response,
-        @Query() paginationParams: PaginationParamsDto,
+        @Query() filters: ExportFiltersDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        const buffer = await this.invoiceService.exportToExcel(tenantId, filters);
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/dto/pagination.dto.ts
+++ b/api/src/application/invoices/dto/pagination.dto.ts
@@ -50,6 +50,33 @@ export class PaginationParamsDto {
     includeArchived?: boolean = false;
 }
 
+/**
+ * DTO for export-specific filters (no pagination — all matching invoices are exported).
+ */
+export class ExportFiltersDto {
+    @ApiProperty({
+        description: 'Filter invoices by status',
+        example: 'PAID',
+        enum: ['PAID', 'UNPAID', 'OVERDUE'],
+        required: false,
+    })
+    @IsString()
+    @IsIn(['PAID', 'UNPAID', 'OVERDUE'])
+    @IsOptional()
+    status?: string;
+
+    @ApiProperty({
+        description: 'Include archived invoices in export',
+        example: false,
+        default: false,
+        required: false,
+    })
+    @IsBoolean()
+    @IsOptional()
+    @Transform(({ value }) => value === 'true' || value === true)
+    includeArchived?: boolean = false;
+}
+
 export class PaginatedResponseDto<T> {
     @ApiProperty({
         description: 'Array of items for the current page',

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -1,5 +1,5 @@
 import { InvoiceDto } from '../dto/invoice.dto';
-import { PaginatedResponseDto } from '../dto/pagination.dto';
+import { PaginatedResponseDto, ExportFiltersDto } from '../dto/pagination.dto';
 import { PaginationParamsDto } from '../dto/pagination.dto';
 
 export const INVOICE_SERVICE = 'INVOICE_SERVICE';
@@ -16,7 +16,12 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    /**
+     * Export all matching invoices to an Excel buffer.
+     * No pagination is applied — every invoice that matches the supplied
+     * filters is included in the exported file.
+     */
+    exportToExcel(tenantId: string, filters?: ExportFiltersDto): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -4,7 +4,7 @@ import { IInvoiceService } from './interfaces/invoice.service.interface';
 import { InvoiceRepository } from '../repositories/invoice.repository';
 import { InvoiceMapper } from './invoice.mapper';
 import { InvoiceDto } from './dto/invoice.dto';
-import { PaginatedResponseDto, PaginationParamsDto } from './dto/pagination.dto';
+import { PaginatedResponseDto, PaginationParamsDto, ExportFiltersDto } from './dto/pagination.dto';
 import { Invoice } from '../../domain/entities/invoice.entity';
 import { InvoiceItem } from '../../domain/entities/invoice-item.entity';
 
@@ -106,9 +106,10 @@ export class InvoiceService implements IInvoiceService {
 
     async exportToExcel(
         tenantId: string,
-        paginationParams: PaginationParamsDto,
+        filters?: ExportFiltersDto,
     ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+        // Fetch ALL invoices without pagination so every matching record is exported
+        const invoices = await this.invoiceRepository.findAllForExport(tenantId, filters);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Invoice } from '../../domain/entities/invoice.entity';
-import { PaginationParamsDto } from '../invoices/dto/pagination.dto';
+import { PaginationParamsDto, ExportFiltersDto } from '../invoices/dto/pagination.dto';
 import { AnalyticsFiltersDto } from '../analytics/dto/analytics-filters.dto';
 
 @Injectable()
@@ -35,6 +35,34 @@ export class InvoiceRepository {
             where: whereClause,
             skip,
             take: limit,
+            order: {
+                issueDate: 'DESC',
+            },
+        });
+    }
+
+    /**
+     * Fetch all invoices for a tenant without pagination, respecting optional filters.
+     * Used exclusively for the export-to-Excel flow so that every matching invoice
+     * is included regardless of how many pages exist in the UI.
+     */
+    async findAllForExport(
+        tenantId: string,
+        filters?: ExportFiltersDto,
+    ): Promise<Invoice[]> {
+        const whereClause: { tenantId: string; status?: string; isArchived?: boolean } = { tenantId };
+
+        if (filters?.status) {
+            whereClause.status = filters.status;
+        }
+
+        // Exclude archived invoices unless the caller explicitly opts in
+        if (!filters?.includeArchived) {
+            whereClause.isArchived = false;
+        }
+
+        return this.invoiceRepository.find({
+            where: whereClause,
             order: {
                 issueDate: 'DESC',
             },

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -258,11 +258,11 @@ const InvoiceManagementPage: React.FC = () => {
     setPage(1); // Reset to first page when changing limit
   };
 
-  // Handle export to Excel
+  // Handle export to Excel — exports ALL matching invoices, ignoring current pagination
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      const blob = await invoiceService.exportInvoices(statusFilter || undefined, includeArchived);
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,22 +80,22 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
+   * Export ALL invoices to an Excel file.
+   * No pagination is applied — every invoice that matches the supplied filters
+   * is included in the downloaded file.
+   *
    * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * @param includeArchived - Whether to include archived invoices (default: false)
    * @returns Promise<Blob>
    */
   exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
     status?: string,
+    includeArchived: boolean = false,
   ): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
       params: {
-        page,
-        limit,
         ...(status && { status }),
+        includeArchived,
       },
       responseType: 'blob',
     });


### PR DESCRIPTION
Implementation of IA-486

Currently, when a user tries to export invoices, only the invoices visible on a page are exported.
Expected result: all invoices, regardless of pagination and filtering, must be exported

# Implementation Plan

## Conceptual Checklist

- Understand current export flow end-to-end (frontend → API → service → repository)
- Determine what "all invoices" means in terms of filters
- Modify backend to support unpaginated export
- Modify frontend to call export without pagination params
- Ensure the includeArchived flag is also forwarded appropriately

## Overview

Remove pagination constraints from the invoice export flow so all matching invoices are exported. Modify both backend (repository query) and frontend (API call) to not limit results by page/limit.

## Assumptions and Rules from CLAUDE.md

- Dependencies point inward: API → Application → Domain (project CLAUDE.md)
- Use DTOs for data transfer between layers (project CLAUDE.md)
- ESLint runs before dev; use `npm run lint:fix` to resolve issues (project CLAUDE.md)
- Assuming filters (status, includeArchived) should still be respected but pagination removed

## Step-by-Step Implementation

1. **Add `findAllWithoutPagination` method to InvoiceRepository**
- File: `api/src/application/repositories/invoice.repository.ts`
- New method that accepts tenantId and optional filters (status, includeArchived) but no page/limit
- Uses TypeORM `find` instead of `findAndCount` with no skip/take

2. **Create ExportParamsDto or modify service signature**
- File: `api/src/application/invoices/dto/pagination.dto.ts`
- Either create a new DTO with only filter fields (status, includeArchived) or reuse PaginationParamsDto but ignore page/limit in the export method

3. **Update `exportToExcel` in InvoiceService**
- File: `api/src/application/invoices/invoice.service.ts`
- Call the new repository method that doesn't paginate
- Keep status/includeArchived filters

4. **Update service interface**
- File: `api/src/application/invoices/interfaces/invoice.service.interface.ts`
- Update signature if DTO changed

5. **Update controller export endpoint**
- File: `api/src/api/controllers/invoice.controller.ts`
- Remove page/limit from @ApiQuery docs or make them irrelevant
- Pass only filter params to service

6. **Update frontend service call**
- File: `client/src/modules/invoices/services/invoiceService.ts`
- Remove page/limit params from `exportInvoices`, keep status and add includeArchived

7. **Update frontend handler**
- File: `client/src/modules/invoices/components/InvoiceManagementPage.tsx`
- Call `exportInvoices(statusFilter, includeArchived)` without page/limit

## Error Handling and Uncertainties

- **Large dataset risk**: If there are thousands of invoices, exporting all at once could cause memory/timeout issues. Consider streaming or chunked generation for very large datasets.
- **Filter ambiguity**: The task says "regardless of filtering" — assumed to mean keep current filters active (most common UX). If user wants NO filters, remove status/includeArchived params entirely.
- **includeArchived not currently passed**: The existing frontend export doesn't pass includeArchived — need to decide whether to add it or default to including all.