### PR TITLE
IA-490 Resolve issue with export to Excel on invoices page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -192,25 +192,7 @@ export class InvoiceController {
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
         summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
-    })
-    @ApiQuery({
-        name: 'status',
-        required: false,
-        enum: ['PAID', 'UNPAID', 'OVERDUE'],
-        description: 'Filter invoices by status',
+        description: 'Exports all invoices for the tenant to an Excel file, ignoring pagination and filters',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -221,10 +203,9 @@ export class InvoiceController {
     async exportToExcel(
         @Req() request: RequestWithTenant,
         @Res() response: Response,
-        @Query() paginationParams: PaginationParamsDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        const buffer = await this.invoiceService.exportToExcel(tenantId);
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -16,7 +16,7 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    exportToExcel(tenantId: string): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -104,11 +104,8 @@ export class InvoiceService implements IInvoiceService {
         await this.invoiceRepository.remove(id, tenantId);
     }
 
-    async exportToExcel(
-        tenantId: string,
-        paginationParams: PaginationParamsDto,
-    ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+    async exportToExcel(tenantId: string): Promise<Buffer> {
+        const invoices = await this.invoiceRepository.findAllForExport(tenantId);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -41,6 +41,19 @@ export class InvoiceRepository {
         });
     }
 
+    /**
+     * Retrieves all invoices for a tenant without pagination or filtering.
+     * Used exclusively for full data exports.
+     */
+    async findAllForExport(tenantId: string): Promise<Invoice[]> {
+        return this.invoiceRepository.find({
+            where: { tenantId },
+            order: {
+                issueDate: 'DESC',
+            },
+        });
+    }
+
     async findById(id: string, tenantId: string): Promise<Invoice | null> {
         return this.invoiceRepository.findOne({
             where: { id, tenantId },

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -262,7 +262,7 @@ const InvoiceManagementPage: React.FC = () => {
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      const blob = await invoiceService.exportInvoices();
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,23 +80,11 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
-   * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * Export all invoices to Excel file (no pagination or filtering applied)
    * @returns Promise<Blob>
    */
-  exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
-    status?: string,
-  ): Promise<Blob> => {
+  exportInvoices: async (): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
-      params: {
-        page,
-        limit,
-        ...(status && { status }),
-      },
       responseType: 'blob',
     });
     return response.data;


### PR DESCRIPTION
Implementation of IA-490

Currently, when a user tries to export invoices, only the invoices visible on a page are exported.
Expected result: all invoices, regardless of pagination and filtering, must be exported

# Implementation Plan

## Conceptual Checklist

- Identify all layers that enforce pagination on export (frontend service, backend controller, backend service, repository)
- Determine the cleanest approach to bypass pagination without breaking existing list functionality
- Ensure the repository can return all records when no pagination is specified
- Update frontend to not pass page/limit params for export
- Maintain backward compatibility for the paginated list endpoint

## Overview

Remove pagination and filtering constraints from the invoice Excel export flow so that ALL invoices for the tenant are exported regardless of current UI state.

## Assumptions and Rules from CLAUDE.md

- Dependencies point inward: API → Application → Domain (project CLAUDE.md)
- Use DTOs for data transfer between layers (project CLAUDE.md)
- ESLint runs before dev server; code must pass linting (project CLAUDE.md)
- Assumption: Export ALL invoices (ignoring filters) per task wording

## Step-by-Step Implementation

1. **Backend Repository** - Add `findAllForExport(tenantId)` method or modify `findAll` to skip pagination when limit is not provided
- File: `api/src/application/repositories/invoice.repository.ts`
- Add method that queries without skip/take/status/archive filters

2. **Backend Service** - Update `exportToExcel` to call the new unpaginated query
- File: `api/src/application/invoices/invoice.service.ts` (line 107-111)
- Remove paginationParams dependency or ignore them

3. **Backend Service Interface** - Update interface signature
- File: `api/src/application/invoices/interfaces/invoice.service.interface.ts`

4. **Backend Controller** - Remove pagination query params from export endpoint
- File: `api/src/api/controllers/invoice.controller.ts` (lines 191-232)
- Remove @ApiQuery decorators for page/limit/status on export endpoint

5. **Frontend Service** - Remove page/limit/status params from exportInvoices call
- File: `client/src/modules/invoices/services/invoiceService.ts` (lines 89-103)

6. **Frontend Page** - Update handleExportToExcel to not pass current pagination state
- File: `client/src/modules/invoices/components/InvoiceManagementPage.tsx` (line 265)

## Error Handling and Uncertainties

- Large dataset concern: If tenant has thousands of invoices, exporting all at once could cause memory/timeout issues. Consider streaming or chunked approach if needed.
- The ambiguity about filter behavior (status/archive) needs clarification from stakeholder.