### PR TITLE
IA-492 Resolve issue with export to Excel on invoices page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -192,25 +192,7 @@ export class InvoiceController {
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
         summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
-    })
-    @ApiQuery({
-        name: 'status',
-        required: false,
-        enum: ['PAID', 'UNPAID', 'OVERDUE'],
-        description: 'Filter invoices by status',
+        description: 'Exports all non-archived invoices to an Excel file',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -221,10 +203,9 @@ export class InvoiceController {
     async exportToExcel(
         @Req() request: RequestWithTenant,
         @Res() response: Response,
-        @Query() paginationParams: PaginationParamsDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        const buffer = await this.invoiceService.exportToExcel(tenantId);
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -16,7 +16,7 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    exportToExcel(tenantId: string): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -104,11 +104,8 @@ export class InvoiceService implements IInvoiceService {
         await this.invoiceRepository.remove(id, tenantId);
     }
 
-    async exportToExcel(
-        tenantId: string,
-        paginationParams: PaginationParamsDto,
-    ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+    async exportToExcel(tenantId: string): Promise<Buffer> {
+        const invoices = await this.invoiceRepository.findAllUnpaginated(tenantId);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -41,6 +41,15 @@ export class InvoiceRepository {
         });
     }
 
+    async findAllUnpaginated(tenantId: string): Promise<Invoice[]> {
+        return this.invoiceRepository.find({
+            where: { tenantId, isArchived: false },
+            order: {
+                issueDate: 'DESC',
+            },
+        });
+    }
+
     async findById(id: string, tenantId: string): Promise<Invoice | null> {
         return this.invoiceRepository.findOne({
             where: { id, tenantId },

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -262,7 +262,7 @@ const InvoiceManagementPage: React.FC = () => {
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      const blob = await invoiceService.exportInvoices();
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,23 +80,11 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
-   * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * Export all non-archived invoices to Excel file
    * @returns Promise<Blob>
    */
-  exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
-    status?: string,
-  ): Promise<Blob> => {
+  exportInvoices: async (): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
-      params: {
-        page,
-        limit,
-        ...(status && { status }),
-      },
       responseType: 'blob',
     });
     return response.data;


### PR DESCRIPTION
Implementation of IA-492

Currently, when a user tries to export invoices, only the invoices visible on a page are exported.
Expected result: all invoices, regardless of pagination and filtering, must be exported

# Implementation Plan

## Conceptual Checklist

- Identify all files requiring changes (frontend service, frontend handler, backend service, backend controller)
- Determine if a new repository method is needed or if existing `findAll` can be adapted
- Ensure the export endpoint no longer accepts/uses pagination params
- Verify no memory issues with large datasets (streaming consideration)
- Maintain existing Excel formatting and column structure
- Keep authorization unchanged (SUPER_ADMIN only)

## Overview

Modify the invoice export feature to fetch ALL invoices for a tenant (without pagination or filtering) and export them to Excel. Changes span frontend (remove params from export call) and backend (fetch all records without skip/take).

## Assumptions and Rules from CLAUDE.md

- Clean architecture: changes follow inward dependency direction (API → Application → Domain)
- Repository pattern: may need a new `findAllForExport` method or modify params
- No business logic in infrastructure/presentation layers
- Use DTOs for data transfer between layers

## Step-by-Step Implementation

1. **Backend Repository** - Add a `findAllUnpaginated` method in `api/src/application/repositories/invoice.repository.ts`
- Query all invoices for tenant with `isArchived = false`, ordered by `issueDate DESC`, no `skip`/`take`
- Dependencies: None

2. **Backend Service** - Update `exportToExcel` in `api/src/application/invoices/invoice.service.ts`
- Remove `paginationParams` parameter, call new `findAllUnpaginated(tenantId)` instead
- Dependencies: Step 1

3. **Backend Controller** - Update export endpoint in `api/src/api/controllers/invoice.controller.ts`
- Remove `@Query() paginationParams` from `exportToExcel` method
- Update API docs (remove page/limit/status query params)
- Dependencies: Step 2

4. **Frontend Service** - Update `exportInvoices` in `client/src/modules/invoices/services/invoiceService.ts`
- Remove `page`, `limit`, `status` params; call endpoint with no query params
- Dependencies: None (can be done in parallel with backend)

5. **Frontend Handler** - Update `handleExportToExcel` in `client/src/modules/invoices/components/InvoiceManagementPage.tsx`
- Call `invoiceService.exportInvoices()` with no arguments
- Dependencies: Step 4

6. **Backend Interface** - Update `IInvoiceService` in `api/src/application/invoices/interfaces/invoice.service.interface.ts`
- Update `exportToExcel` signature to remove `paginationParams`

## Error Handling and Uncertainties

- **Large dataset concern**: If tenant has thousands of invoices, loading all into memory could be problematic. ExcelJS supports streaming but current implementation uses buffer. For now, assume dataset size is manageable.
- **Archived invoices**: Assuming we exclude archived by default (consistent with list behavior).
- **Filter ambiguity**: Task says 'regardless of filtering' - implementing as no filters applied to export.