### PR TITLE
IA-499 add reset password option in the user profile menu

### DIFF
--- a/client/src/common/components/ChangePasswordDialog.tsx
+++ b/client/src/common/components/ChangePasswordDialog.tsx
@@ -57,8 +57,15 @@ const ChangePasswordDialog: React.FC<ChangePasswordDialogProps> = ({ open, onClo
     validationSchema,
     onSubmit: async (values, { setSubmitting, resetForm }) => {
       setErrorMessage(null);
+
+      if (!user) {
+        setErrorMessage('User session not found. Please refresh the page and try again.');
+        setSubmitting(false);
+        return;
+      }
+
       try {
-        await user?.updatePassword({
+        await user.updatePassword({
           currentPassword: values.currentPassword,
           newPassword: values.newPassword,
         });
@@ -70,6 +77,7 @@ const ChangePasswordDialog: React.FC<ChangePasswordDialogProps> = ({ open, onClo
         const message =
           clerkError?.errors?.[0]?.longMessage ||
           clerkError?.errors?.[0]?.message ||
+          (err instanceof Error ? err.message : null) ||
           'Failed to change password. Please try again.';
         setErrorMessage(message);
       } finally {

--- a/client/src/common/components/ChangePasswordDialog.tsx
+++ b/client/src/common/components/ChangePasswordDialog.tsx
@@ -1,0 +1,205 @@
+import React, { useState } from 'react';
+import { useUser } from '@clerk/clerk-react';
+import { useSnackbar } from 'notistack';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Box,
+  CircularProgress,
+  Alert,
+  IconButton,
+  InputAdornment,
+} from '@mui/material';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import { useFormik } from 'formik';
+import * as Yup from 'yup';
+
+type ChangePasswordDialogProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+type ChangePasswordFormValues = {
+  currentPassword: string;
+  newPassword: string;
+  confirmNewPassword: string;
+};
+
+const validationSchema = Yup.object({
+  currentPassword: Yup.string().required('Current password is required'),
+  newPassword: Yup.string()
+    .min(8, 'Password must be at least 8 characters')
+    .required('New password is required'),
+  confirmNewPassword: Yup.string()
+    .oneOf([Yup.ref('newPassword')], 'Passwords do not match')
+    .required('Please confirm your new password'),
+});
+
+const ChangePasswordDialog: React.FC<ChangePasswordDialogProps> = ({ open, onClose }) => {
+  const { user } = useUser();
+  const { enqueueSnackbar } = useSnackbar();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const formik = useFormik<ChangePasswordFormValues>({
+    initialValues: {
+      currentPassword: '',
+      newPassword: '',
+      confirmNewPassword: '',
+    },
+    validationSchema,
+    onSubmit: async (values, { setSubmitting, resetForm }) => {
+      setErrorMessage(null);
+      try {
+        await user?.updatePassword({
+          currentPassword: values.currentPassword,
+          newPassword: values.newPassword,
+        });
+        enqueueSnackbar('Password changed successfully', { variant: 'success' });
+        resetForm();
+        onClose();
+      } catch (err: unknown) {
+        const clerkError = err as { errors?: Array<{ message?: string; longMessage?: string }> };
+        const message =
+          clerkError?.errors?.[0]?.longMessage ||
+          clerkError?.errors?.[0]?.message ||
+          'Failed to change password. Please try again.';
+        setErrorMessage(message);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+  });
+
+  const handleClose = (): void => {
+    if (formik.isSubmitting) return;
+    formik.resetForm();
+    setErrorMessage(null);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Change Password</DialogTitle>
+      <DialogContent>
+        <Box
+          component="form"
+          noValidate
+          autoComplete="off"
+          onSubmit={formik.handleSubmit}
+          sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          {errorMessage && (
+            <Alert severity="error" onClose={() => setErrorMessage(null)}>
+              {errorMessage}
+            </Alert>
+          )}
+
+          <TextField
+            id="currentPassword"
+            name="currentPassword"
+            label="Current Password"
+            type={showCurrentPassword ? 'text' : 'password'}
+            variant="outlined"
+            fullWidth
+            value={formik.values.currentPassword}
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+            error={formik.touched.currentPassword && Boolean(formik.errors.currentPassword)}
+            helperText={formik.touched.currentPassword && formik.errors.currentPassword}
+            disabled={formik.isSubmitting}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="toggle current password visibility"
+                    onClick={() => setShowCurrentPassword((prev) => !prev)}
+                    edge="end">
+                    {showCurrentPassword ? <VisibilityOff /> : <Visibility />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+
+          <TextField
+            id="newPassword"
+            name="newPassword"
+            label="New Password"
+            type={showNewPassword ? 'text' : 'password'}
+            variant="outlined"
+            fullWidth
+            value={formik.values.newPassword}
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+            error={formik.touched.newPassword && Boolean(formik.errors.newPassword)}
+            helperText={formik.touched.newPassword && formik.errors.newPassword}
+            disabled={formik.isSubmitting}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="toggle new password visibility"
+                    onClick={() => setShowNewPassword((prev) => !prev)}
+                    edge="end">
+                    {showNewPassword ? <VisibilityOff /> : <Visibility />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+
+          <TextField
+            id="confirmNewPassword"
+            name="confirmNewPassword"
+            label="Confirm New Password"
+            type={showConfirmPassword ? 'text' : 'password'}
+            variant="outlined"
+            fullWidth
+            value={formik.values.confirmNewPassword}
+            onChange={formik.handleChange}
+            onBlur={formik.handleBlur}
+            error={
+              formik.touched.confirmNewPassword && Boolean(formik.errors.confirmNewPassword)
+            }
+            helperText={formik.touched.confirmNewPassword && formik.errors.confirmNewPassword}
+            disabled={formik.isSubmitting}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="toggle confirm password visibility"
+                    onClick={() => setShowConfirmPassword((prev) => !prev)}
+                    edge="end">
+                    {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={handleClose} color="inherit" disabled={formik.isSubmitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => formik.handleSubmit()}
+          variant="contained"
+          color="primary"
+          disabled={formik.isSubmitting || !formik.isValid || !formik.dirty}
+          startIcon={formik.isSubmitting ? <CircularProgress size={20} color="inherit" /> : null}>
+          {formik.isSubmitting ? 'Changing...' : 'Change Password'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ChangePasswordDialog;

--- a/client/src/common/components/CustomUserButton.tsx
+++ b/client/src/common/components/CustomUserButton.tsx
@@ -15,7 +15,9 @@ import {
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import LogoutIcon from '@mui/icons-material/Logout';
+import LockIcon from '@mui/icons-material/Lock';
 import { useClerk, useUser } from '@clerk/clerk-react';
+import ChangePasswordDialog from './ChangePasswordDialog';
 
 type CustomUserButtonProps = {
   afterSignOutUrl: string;
@@ -23,6 +25,7 @@ type CustomUserButtonProps = {
 
 const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
+  const [changePasswordOpen, setChangePasswordOpen] = useState(false);
   const buttonRef = useRef<HTMLDivElement>(null);
   const { signOut } = useClerk();
   const { user } = useUser();
@@ -45,6 +48,15 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
 
   const handleManageAccount = (): void => {
     handleClose();
+  };
+
+  const handleChangePasswordOpen = (): void => {
+    handleClose();
+    setChangePasswordOpen(true);
+  };
+
+  const handleChangePasswordClose = (): void => {
+    setChangePasswordOpen(false);
   };
 
   const open = Boolean(anchorEl);
@@ -159,6 +171,22 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
 
           <ListItem disablePadding>
             <ListItemButton
+              onClick={handleChangePasswordOpen}
+              sx={{
+                px: 2,
+                '&:hover': {
+                  backgroundColor: theme.palette.action.hover,
+                },
+              }}>
+              <ListItemIcon sx={{ minWidth: 36, color: theme.palette.primary.main }}>
+                <LockIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText primary="Change password" />
+            </ListItemButton>
+          </ListItem>
+
+          <ListItem disablePadding>
+            <ListItemButton
               onClick={handleSignOut}
               sx={{
                 px: 2,
@@ -174,6 +202,8 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
           </ListItem>
         </List>
       </Popover>
+
+      <ChangePasswordDialog open={changePasswordOpen} onClose={handleChangePasswordClose} />
     </>
   );
 };


### PR DESCRIPTION
Implementation of IA-499

add reset password option in the user profile menu

# Implementation Plan

## Conceptual Checklist

- Confirm exact file to modify: `CustomUserButton.tsx`
- Determine Clerk API to use: `user.updatePassword({ currentPassword, newPassword })`
- Design dialog component structure (Formik + Yup, MUI Dialog)
- Add new menu item to the Popover list
- Handle loading, error, and success states
- Ensure linting passes (ESLint runs before dev server)

## Overview

Add a "Change Password" menu item to the existing `CustomUserButton` popover. Clicking it opens a MUI Dialog with a Formik form (current password, new password, confirm new password). On submit, calls Clerk's `user.updatePassword()`. On success, closes the dialog and shows a success message.

## Assumptions and Rules from CLAUDE.md

- **Assumption:** Using in-app change password dialog (user.updatePassword) since user is already logged in.
- **Assumption:** New component will follow the existing MUI + Formik + Yup pattern used across the codebase.
- **Rule (project CLAUDE.md):** Use `npm run lint:fix` to resolve linting before committing.
- **Rule (project CLAUDE.md):** Clerk hooks (`useUser`, `useClerk`) are the standard auth integration point.
- **Rule (client CLAUDE.md):** Forms use Formik for state + Yup for validation; MUI components for UI.
- **Rule (client CLAUDE.md):** No manual token handling needed — Clerk manages this.

## Step-by-Step Implementation

1. **Add `LockIcon` import and `useSignIn`/`useUser` to `CustomUserButton.tsx`**
- Dependencies: existing `@clerk/clerk-react`, `@mui/icons-material`
- Files: `client/src/common/components/CustomUserButton.tsx`

2. **Add dialog state to `CustomUserButton`**
- Add `changePasswordOpen` boolean state
- Add `handleChangePasswordOpen` / `handleChangePasswordClose` handlers

3. **Add 'Change Password' `ListItemButton` to the Popover list**
- Insert between 'Manage account' and 'Sign out'
- Use `LockIcon` from MUI icons, consistent with existing icon style

4. **Create `ChangePasswordDialog` component** (inline or separate file in `client/src/common/components/`)
- Formik form with fields: `currentPassword`, `newPassword`, `confirmNewPassword`
- Yup schema: required fields, min length 8, passwords match
- On submit: call `user.updatePassword({ currentPassword, newPassword })`
- Show MUI `CircularProgress` during submission
- Show error `Alert` on failure (e.g., wrong current password)
- Show success state and auto-close on success

5. **Wire dialog into `CustomUserButton`**
- Pass `open` and `onClose` props to `ChangePasswordDialog`
- Import and render `ChangePasswordDialog` below the `Popover`

6. **Run linting**
- `cd client && npm run lint:fix`

## Error Handling and Uncertainties

- **Clerk error codes:** `user.updatePassword()` throws Clerk errors (e.g., `form_password_incorrect`). Must catch and display user-friendly messages.
- **Password requirements:** Clerk enforces its own password policy; display Clerk's error message directly to the user.
- **`user` may be null:** Guard with early return if `useUser()` returns null.
- **If task means email reset (not change):** The entire implementation would shift to `signIn.create({ strategy: 'reset_password_email_code' })` — confirm with stakeholder before building.