### PR TITLE
IA-501 Resolve issue with export to Excel on invoices page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -191,26 +191,20 @@ export class InvoiceController {
     @Get('export/excel')
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
-        summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
+        summary: 'Export all invoices to Excel',
+        description: 'Exports ALL invoices (regardless of pagination) to an Excel file, with optional status and archived filters',
     })
     @ApiQuery({
         name: 'status',
         required: false,
         enum: ['PAID', 'UNPAID', 'OVERDUE'],
-        description: 'Filter invoices by status',
+        description: 'Filter exported invoices by status',
+    })
+    @ApiQuery({
+        name: 'includeArchived',
+        required: false,
+        type: Boolean,
+        description: 'Include archived invoices in the export (default: false)',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -224,7 +218,12 @@ export class InvoiceController {
         @Query() paginationParams: PaginationParamsDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        // Pass only filter params — pagination is intentionally omitted so all matching invoices are exported
+        const buffer = await this.invoiceService.exportToExcel(
+            tenantId,
+            paginationParams.status,
+            paginationParams.includeArchived,
+        );
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -1,6 +1,5 @@
 import { InvoiceDto } from '../dto/invoice.dto';
-import { PaginatedResponseDto } from '../dto/pagination.dto';
-import { PaginationParamsDto } from '../dto/pagination.dto';
+import { PaginatedResponseDto, PaginationParamsDto } from '../dto/pagination.dto';
 
 export const INVOICE_SERVICE = 'INVOICE_SERVICE';
 
@@ -16,7 +15,11 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    /**
+     * Exports all invoices (no pagination) to an Excel buffer.
+     * Optional filters are forwarded to the repository layer.
+     */
+    exportToExcel(tenantId: string, status?: string, includeArchived?: boolean): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -106,9 +106,10 @@ export class InvoiceService implements IInvoiceService {
 
     async exportToExcel(
         tenantId: string,
-        paginationParams: PaginationParamsDto,
+        status?: string,
+        includeArchived?: boolean,
     ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+        const invoices = await this.invoiceRepository.findAllForExport(tenantId, status, includeArchived);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -41,6 +41,38 @@ export class InvoiceRepository {
         });
     }
 
+    /**
+     * Retrieves all invoices for a tenant without any pagination constraints.
+     * Intended exclusively for export operations where the full dataset is required.
+     *
+     * @param tenantId - The tenant whose invoices to retrieve
+     * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+     * @param includeArchived - When true, archived invoices are included; default false
+     */
+    async findAllForExport(
+        tenantId: string,
+        status?: string,
+        includeArchived?: boolean,
+    ): Promise<Invoice[]> {
+        const whereClause: any = { tenantId };
+
+        if (status) {
+            whereClause.status = status;
+        }
+
+        // By default, exclude archived invoices unless explicitly requested
+        if (!includeArchived) {
+            whereClause.isArchived = false;
+        }
+
+        return this.invoiceRepository.find({
+            where: whereClause,
+            order: {
+                issueDate: 'DESC',
+            },
+        });
+    }
+
     async findById(id: string, tenantId: string): Promise<Invoice | null> {
         return this.invoiceRepository.findOne({
             where: { id, tenantId },

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -258,11 +258,11 @@ const InvoiceManagementPage: React.FC = () => {
     setPage(1); // Reset to first page when changing limit
   };
 
-  // Handle export to Excel
+  // Handle export to Excel — exports ALL invoices (no pagination), preserving active filters
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      const blob = await invoiceService.exportInvoices(statusFilter || undefined, includeArchived);
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,22 +80,19 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
+   * Export ALL invoices to Excel file (no pagination — all matching records are returned).
    * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * @param includeArchived - Include archived invoices in the export (default: false)
    * @returns Promise<Blob>
    */
   exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
     status?: string,
+    includeArchived: boolean = false,
   ): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
       params: {
-        page,
-        limit,
         ...(status && { status }),
+        includeArchived,
       },
       responseType: 'blob',
     });


### PR DESCRIPTION
Implementation of IA-501

Currently, when a user tries to export invoices, only the invoices visible on a page are exported.
Expected result: all invoices, regardless of pagination and filtering, must be exported

# Implementation Plan

## Conceptual Checklist

- Identify all layers touched by the export flow (repository → service → controller → frontend service → component)
- Decide the cleanest way to bypass pagination in the repository without breaking the existing paginated list endpoint
- Ensure status and includeArchived filters are still forwarded correctly to the export endpoint
- Align the frontend export call to omit page/limit (or signal "all")
- Verify no interface/DTO changes break other callers

## Overview

The invoice export endpoint reuses the same paginated `findAll` repository query used for the table view, so only the current page is returned. The fix is to give the export path its own repository method that omits `skip`/`take`, and update the service, controller, and frontend accordingly.

## Assumptions and Rules from CLAUDE.md

- **Assumption:** Filters (status, includeArchived) are preserved during export; only pagination is removed.
- **Clean Architecture rule (project CLAUDE.md):** Dependencies point inward. Repository changes stay in infrastructure; service changes stay in application. No business logic added to the controller.
- **CQRS rule:** `exportToExcel` is a query-side operation; no command side changes needed.
- **Linting policy:** Run `npm run lint` after changes; fix any issues before committing.

## Step-by-Step Implementation

1. **Add `findAllForExport` to the invoice repository**
- File: `api/src/application/repositories/invoice.repository.ts`
- New method accepts `tenantId` + filter params (status, includeArchived) but omits `skip`/`take`.
- Returns `Invoice[]` (no count needed).

2. **Update `IInvoiceRepository` interface** (if one exists) to declare the new method.
- File: `api/src/application/repositories/invoice.repository.interface.ts` (verify path)

3. **Update `exportToExcel` in `invoice.service.ts`**
- File: `api/src/application/invoices/invoice.service.ts`
- Call `this.invoiceRepository.findAllForExport(tenantId, { status, includeArchived })` instead of `findAll`.
- Remove dependency on `paginationParams.page` / `paginationParams.limit`.

4. **Update `IInvoiceService` interface** signature if `paginationParams` is removed from `exportToExcel`.
- File: `api/src/application/invoices/interfaces/invoice.service.interface.ts`

5. **Update frontend service `exportInvoices`**
- File: `client/src/modules/invoices/services/invoiceService.ts`
- Remove `page` and `limit` params; add `includeArchived?: boolean` param.
- Send only `status` and `includeArchived` as query params.

6. **Update `handleExportToExcel` in `InvoiceManagementPage`**
- File: `client/src/modules/invoices/components/InvoiceManagementPage.tsx`
- Call `invoiceService.exportInvoices(statusFilter || undefined, includeArchived)` — drop `page`/`limit`.

## Error Handling and Uncertainties

- **Large datasets:** Exporting thousands of rows without pagination could cause memory pressure. Mitigation: acceptable for now; streaming can be added later if needed.
- **Client-side date/text filters:** These are applied purely on the frontend after fetching and are not sent to the API, so they cannot be replicated in the export without either sending them to the backend or re-filtering the export result on the client. Given the assumption above (respect filters), this is a known gap to document.
- **Interface mismatch risk:** If `PaginationParamsDto` is still accepted by the controller for the export endpoint, removing it from the service means the controller silently ignores those params — this is fine and backward-compatible.