### PR TITLE
IA-510 add reset password option in the user profile menu

### DIFF
--- a/client/src/common/components/CustomUserButton.tsx
+++ b/client/src/common/components/CustomUserButton.tsx
@@ -15,7 +15,9 @@ import {
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import LogoutIcon from '@mui/icons-material/Logout';
-import { useClerk, useUser } from '@clerk/clerk-react';
+import LockResetIcon from '@mui/icons-material/LockReset';
+import { useClerk, useUser, useSignIn } from '@clerk/clerk-react';
+import { useSnackbar } from 'notistack';
 
 type CustomUserButtonProps = {
   afterSignOutUrl: string;
@@ -23,9 +25,12 @@ type CustomUserButtonProps = {
 
 const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
+  const [isResettingPassword, setIsResettingPassword] = useState(false);
   const buttonRef = useRef<HTMLDivElement>(null);
   const { signOut } = useClerk();
   const { user } = useUser();
+  const { signIn, isLoaded } = useSignIn();
+  const { enqueueSnackbar } = useSnackbar();
   const theme = useTheme();
 
   const handleClick = (): void => {
@@ -45,6 +50,35 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
 
   const handleManageAccount = (): void => {
     handleClose();
+  };
+
+  const handleResetPassword = async (): Promise<void> => {
+    handleClose();
+
+    if (!isLoaded || isResettingPassword) return;
+
+    const email = user?.primaryEmailAddress?.emailAddress;
+    if (!email) {
+      enqueueSnackbar('No email address found on your account.', { variant: 'error' });
+      return;
+    }
+
+    setIsResettingPassword(true);
+    try {
+      await signIn?.create({
+        strategy: 'reset_password_email_code',
+        identifier: email,
+      });
+      enqueueSnackbar('Password reset email sent. Please check your inbox.', {
+        variant: 'success',
+      });
+    } catch (err) {
+      const message =
+        (err as { message?: string }).message || 'Failed to send password reset email.';
+      enqueueSnackbar(message, { variant: 'error' });
+    } finally {
+      setIsResettingPassword(false);
+    }
   };
 
   const open = Boolean(anchorEl);
@@ -154,6 +188,23 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
                 <SettingsIcon fontSize="small" />
               </ListItemIcon>
               <ListItemText primary="Manage account" />
+            </ListItemButton>
+          </ListItem>
+
+          <ListItem disablePadding>
+            <ListItemButton
+              onClick={handleResetPassword}
+              disabled={isResettingPassword}
+              sx={{
+                px: 2,
+                '&:hover': {
+                  backgroundColor: theme.palette.action.hover,
+                },
+              }}>
+              <ListItemIcon sx={{ minWidth: 36, color: theme.palette.primary.main }}>
+                <LockResetIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText primary="Reset Password" />
             </ListItemButton>
           </ListItem>
 


### PR DESCRIPTION
Implementation of IA-510

add reset password option in the user profile menu

# Implementation Plan

## Conceptual Checklist

- Extend imports in `CustomUserButton.tsx` (`LockResetIcon`, `useSignIn`, `useSnackbar`)
- Add hook calls and `isResettingPassword` state inside the component
- Add `handleResetPassword` async handler with full error handling
- Handle edge cases: unloaded Clerk SDK, missing email, OAuth-only users (no password)
- Insert Reset Password `ListItem` in the Popover's `` block
- Show success toast on email sent; surface Clerk error message on failure

## Overview

Add a "Reset Password" menu item to `CustomUserButton.tsx`. On click: dismiss the popover immediately, call Clerk's `reset_password_email_code` strategy for the signed-in user's primary email, and display a `notistack` success toast. All errors (Clerk API errors, OAuth-only users, unloaded SDK, missing email) are caught and surfaced via an error toast — no silent failures.

## Assumptions and Rules from CLAUDE.md

- **Toast library:** `notistack` (`enqueueSnackbar`) — already used in `TenantManagementPage.tsx`, `TenantForm.tsx`, `UserForm.tsx`; `SnackbarProvider` mounted in `main.tsx`.
- **Clerk reset call:** `signIn.create({ strategy: 'reset_password_email_code', identifier: email })` — mirrors `Login.tsx:85`.
- **No new dependencies** required.
- ESLint runs before dev server starts; code must lint cleanly.

## Step-by-Step Implementation

1. **Extend imports** — `LockResetIcon`, `useSignIn` (added to existing Clerk import), `useSnackbar` from `notistack`.
- Files: `CustomUserButton.tsx` lines 16–18

2. **Add hooks and state** — `useSignIn()`, `useSnackbar()`, `useState(false)` for `isResettingPassword`.
- Files: `CustomUserButton.tsx` (component body, after `useTheme`)

3. **Add `handleResetPassword` with comprehensive error handling**
```tsx
const handleResetPassword = async (): Promise => {
handleClose();
if (!isLoaded || isResettingPassword) return;
const email = user?.primaryEmailAddress?.emailAddress;
if (!email) {
enqueueSnackbar('No email address found on your account.', { variant: 'error' });
return;
}
setIsResettingPassword(true);
try {
await signIn.create({ strategy: 'reset_password_email_code', identifier: email });
enqueueSnackbar('Password reset email sent. Please check your inbox.', { variant: 'success' });
} catch (err) {
const message = (err as { message?: string }).message || 'Failed to send password reset email.';
enqueueSnackbar(message, { variant: 'error' });
} finally {
setIsResettingPassword(false);
}
};
```
- Guards: `isLoaded` (SDK not ready), `isResettingPassword` (double-submit), missing email (no primary address).
- Clerk surfaces a human-readable message for OAuth-only users (no password set) — caught and shown directly.

4. **Insert `ListItem`** between "Manage account" and "Sign out" with `disabled={isResettingPassword}` and `LockResetIcon`.
- Files: `CustomUserButton.tsx` (List block)

## Error Handling and Uncertainties

- **SDK not loaded:** `isLoaded` guard short-circuits before any API call.
- **Missing primary email:** Explicit check with a descriptive error toast.
- **OAuth-only users:** Clerk returns an error with a message — surfaced verbatim via error toast; no special-casing needed.
- **Network / unknown errors:** Caught by the `catch` block; fallback message used if `err.message` is empty.
- **Double-submit:** `isResettingPassword` state disables the button and guards the handler.