### PR TITLE
IA-512 add reset password option in the user profile menu

### DIFF
--- a/client/src/common/components/CustomUserButton.tsx
+++ b/client/src/common/components/CustomUserButton.tsx
@@ -13,9 +13,10 @@ import {
   Tooltip,
   useTheme,
 } from '@mui/material';
-import SettingsIcon from '@mui/icons-material/Settings';
+import LockResetIcon from '@mui/icons-material/LockReset';
 import LogoutIcon from '@mui/icons-material/Logout';
-import { useClerk, useUser } from '@clerk/clerk-react';
+import { useClerk, useUser, useSignIn } from '@clerk/clerk-react';
+import { useSnackbar } from 'notistack';
 
 type CustomUserButtonProps = {
   afterSignOutUrl: string;
@@ -26,6 +27,9 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
   const buttonRef = useRef<HTMLDivElement>(null);
   const { signOut } = useClerk();
   const { user } = useUser();
+  const { signIn, isLoaded: isSignInLoaded } = useSignIn();
+  const { enqueueSnackbar } = useSnackbar();
+  const [isResetting, setIsResetting] = useState(false);
   const theme = useTheme();
 
   const handleClick = (): void => {
@@ -43,8 +47,33 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
     handleClose();
   };
 
-  const handleManageAccount = (): void => {
+  const handleResetPassword = async (): Promise<void> => {
     handleClose();
+
+    if (!isSignInLoaded || !signIn) return;
+
+    const email = user?.emailAddresses[0]?.emailAddress;
+    if (!email) return;
+
+    setIsResetting(true);
+    try {
+      await signIn.create({
+        strategy: 'reset_password_email_code',
+        identifier: email,
+      });
+      enqueueSnackbar('Password reset email sent. Check your inbox.', {
+        variant: 'success',
+      });
+    } catch (err) {
+      const clerkError = err as { errors?: Array<{ longMessage?: string }> };
+      const message =
+        clerkError?.errors?.[0]?.longMessage ||
+        (err as Error).message ||
+        'Failed to send password reset email. Please try again.';
+      enqueueSnackbar(message, { variant: 'error' });
+    } finally {
+      setIsResetting(false);
+    }
   };
 
   const open = Boolean(anchorEl);
@@ -143,7 +172,8 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
         <List disablePadding>
           <ListItem disablePadding>
             <ListItemButton
-              onClick={handleManageAccount}
+              onClick={handleResetPassword}
+              disabled={isResetting}
               sx={{
                 px: 2,
                 '&:hover': {
@@ -151,9 +181,9 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
                 },
               }}>
               <ListItemIcon sx={{ minWidth: 36, color: theme.palette.primary.main }}>
-                <SettingsIcon fontSize="small" />
+                <LockResetIcon fontSize="small" />
               </ListItemIcon>
-              <ListItemText primary="Manage account" />
+              <ListItemText primary="Reset password" />
             </ListItemButton>
           </ListItem>
 


### PR DESCRIPTION
Implementation of IA-512

add reset password option in the user profile menu

# Plan: Reset Password Option in User Profile Menu (IA-512)

## Context

`CustomUserButton.tsx` already renders a user-profile popover with two menu items — "Manage account" (a no-op) and "Sign out". The task wires up the no-op item to trigger a Clerk password-reset email via the `reset_password_email_code` strategy, and renames the item to "Reset password". The entire change is confined to a single file.

**Decisions:**
- **Rename label**: "Manage account" → "Reset password" (directly reflects the single action now performed).
- **Icon**: Swap `SettingsIcon` → `LockResetIcon` from `@mui/icons-material/LockReset` (semantically matches password reset; no extra dep).
- **Feedback**: `useSnackbar` / `enqueueSnackbar` from `notistack` — already the project-wide pattern (`main.tsx:97`, `UserManagementPage.tsx:62`).
- **`useSignIn`**: Import from `@clerk/clerk-react`; already used in `Login.tsx:15` for the same Clerk instance.
- **Loading guard**: Add a local `isResetting` boolean to disable the button while the async call is in flight (prevents double-submissions).
- **OAuth-only edge case**: Wrap in try/catch; surface Clerk's error message via `enqueueSnackbar variant: 'error'` — covers the case where the user has no password-auth method without special-casing.
- **Popover timing**: Close the popover before the async call so the UI feels responsive; the snackbar surfaces the result independently.

## Stack already available (no new deps)

- `@clerk/clerk-react` — `useSignIn` hook (`Login.tsx:15`), `useUser` already imported in `CustomUserButton.tsx:18`.
- `notistack` — `SnackbarProvider` wraps the whole app (`main.tsx:97`); `useSnackbar` / `enqueueSnackbar` pattern at `UserManagementPage.tsx:62–106`.
- `@mui/icons-material/LockReset` — MUI v5 icon, same import shape as existing `SettingsIcon` and `LogoutIcon` in the file.

## Implementation Order

1. **Task 1** — Modify `CustomUserButton.tsx`: add imports, replace handler, rename menu item. (No prerequisites.)

---

## Task 1: Wire up "Reset password" in CustomUserButton

**Files:**
- Modify: `client/src/common/components/CustomUserButton.tsx`

**Why:** `handleManageAccount` at line 46–48 is a stub that only closes the popover; clicking "Manage account" currently does nothing. Replacing it with a Clerk `reset_password_email_code` call and renaming the label fulfils the feature requirement. Without this change, users have no self-service path to reset their password from the app.

- [ ] **Step 1: Add `LockResetIcon`, `useSignIn`, and `useSnackbar` imports**

Locate the two existing import blocks at lines 1–18. Add one new MUI icon import, extend the Clerk import with `useSignIn`, and add the `notistack` import.

```tsx
import LockResetIcon from '@mui/icons-material/LockReset';
// ...
import { useClerk, useUser, useSignIn } from '@clerk/clerk-react';
// ...
import { useSnackbar } from 'notistack';
```

Imports: `LockResetIcon` (new), `useSignIn` (added to existing Clerk import line), `useSnackbar` (new notistack import).

Key points: The existing `SettingsIcon` import on line 16 can be removed once Step 3 is done — do both in one edit to avoid an unused-import lint error.

- [ ] **Step 2: Destructure `useSignIn` and `useSnackbar` inside the component**

Inside `CustomUserButton` (after the existing hook calls at lines 27–29), add the two new hook calls and a loading state.

```tsx
const { signIn, isLoaded: isSignInLoaded } = useSignIn();
const { enqueueSnackbar } = useSnackbar();
const [isResetting, setIsResetting] = useState(false);
```

Key points: `useState` is already imported on line 1, so no extra import is needed. `isLoaded` from `useSignIn` mirrors the guard used in `Login.tsx:59`.

- [ ] **Step 3: Replace `handleManageAccount` with `handleResetPassword`**

Remove the existing no-op `handleManageAccount` function (lines 46–48) and replace it with the async handler below.

```tsx
const handleResetPassword = async (): Promise => {
handleClose();

if (!isSignInLoaded || !signIn) return;

const email = user?.emailAddresses[0]?.emailAddress;
if (!email) return;

setIsResetting(true);
try {
await signIn.create({
strategy: 'reset_password_email_code',
identifier: email,
});
enqueueSnackbar('Password reset email sent. Check your inbox.', {
variant: 'success',
});
} catch (err) {
const message =
(err as { errors?: Array })
?.errors?.[0]?.longMessage ||
(err as Error).message ||
'Failed to send password reset email. Please try again.';
enqueueSnackbar(message, { variant: 'error' });
} finally {
setIsResetting(false);
}
};
```

Key points: Clerk error objects surface their human-readable text in `err.errors[0].longMessage` (Clerk SDK convention). The outer `(err as Error).message` fallback handles unexpected throws. Closing the popover first (`handleClose()`) gives immediate visual feedback before the async work starts.

- [ ] **Step 4: Update the menu item — icon, label, handler, and disabled state**

Locate the `ListItemButton` for "Manage account" (lines 145–158) and apply three changes: swap the icon, rename the label, point to the new handler, and disable while resetting.

```tsx

```

Key points: Remove the `SettingsIcon` JSX usage here (together with its import removal from Step 1) to avoid lint warnings. The `disabled={isResetting}` prop prevents double-clicks during the in-flight request.