### PR TITLE
IA-513 Resolve issue with export to Excel on invoices page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -192,25 +192,7 @@ export class InvoiceController {
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
         summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
-    })
-    @ApiQuery({
-        name: 'status',
-        required: false,
-        enum: ['PAID', 'UNPAID', 'OVERDUE'],
-        description: 'Filter invoices by status',
+        description: 'Exports all tenant invoices to an Excel file, regardless of pagination or filters',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -221,10 +203,9 @@ export class InvoiceController {
     async exportToExcel(
         @Req() request: RequestWithTenant,
         @Res() response: Response,
-        @Query() paginationParams: PaginationParamsDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        const buffer = await this.invoiceService.exportToExcel(tenantId);
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -16,7 +16,7 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    exportToExcel(tenantId: string): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -104,11 +104,8 @@ export class InvoiceService implements IInvoiceService {
         await this.invoiceRepository.remove(id, tenantId);
     }
 
-    async exportToExcel(
-        tenantId: string,
-        paginationParams: PaginationParamsDto,
-    ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+    async exportToExcel(tenantId: string): Promise<Buffer> {
+        const invoices = await this.invoiceRepository.findAllUnpaginated(tenantId);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -41,6 +41,18 @@ export class InvoiceRepository {
         });
     }
 
+    /**
+     * Fetches all invoices for a tenant without pagination, status, or archived filters.
+     */
+    async findAllUnpaginated(tenantId: string): Promise<Invoice[]> {
+        return this.invoiceRepository.find({
+            where: { tenantId },
+            order: {
+                issueDate: 'DESC',
+            },
+        });
+    }
+
     async findById(id: string, tenantId: string): Promise<Invoice | null> {
         return this.invoiceRepository.findOne({
             where: { id, tenantId },

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -262,7 +262,7 @@ const InvoiceManagementPage: React.FC = () => {
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      const blob = await invoiceService.exportInvoices();
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,23 +80,12 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
-   * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * Export all tenant invoices to an Excel file.
+   * No filters or pagination are applied — every invoice in the tenant is included.
    * @returns Promise<Blob>
    */
-  exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
-    status?: string,
-  ): Promise<Blob> => {
+  exportInvoices: async (): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
-      params: {
-        page,
-        limit,
-        ...(status && { status }),
-      },
       responseType: 'blob',
     });
     return response.data;


### PR DESCRIPTION
Implementation of IA-513

Currently, when a user tries to export invoices, only the invoices visible on a page are exported.
Expected result: all invoices, regardless of pagination and filtering, must be exported

# Plan: Export All Tenant Invoices Regardless of Pagination and Filters

## Context

Today the `GET /invoices/export/excel` endpoint forwards the caller's `PaginationParamsDto` (page, limit, status) directly into the repository's `findAll` method, which applies `skip`/`take` and an optional `WHERE status = …` / `WHERE isArchived = false` clause. As a result, clicking "Export to Excel" in the UI produces a file containing only the invoices currently visible on the active page, filtered by whatever status is selected. The fix removes pagination and filtering from the export code path so that every invoice belonging to the tenant is included in the download. Tenant isolation is **preserved** — the `tenantId` scope is kept in place at every layer.

**Decisions:**
- Add a dedicated `findAllForExport` repository method rather than modifying `findAll` — avoids any risk of regressing the paginated list view.
- Remove `paginationParams` from `exportToExcel` signature at every layer (interface, service, controller) — cleaner than keeping a parameter that is intentionally ignored.
- Remove Swagger `@ApiQuery` decorators for `page`, `limit`, and `status` on the export endpoint — they no longer apply and would mislead API consumers.
- Frontend: pass no arguments to `exportInvoices()` — matches the updated service signature and the confirmed acceptance criteria (ignore all filters).

## Stack already available (no new deps)

TypeORM `Repository` is already used for all data access; the new `findAllForExport` method follows the `findAll` pattern in `api/src/application/repositories/invoice.repository.ts:15-42` (same `where: { tenantId }` shape, same `order` block, just no `skip`/`take` or status/isArchived clauses). ExcelJS workbook pipeline in `invoice.service.ts:107-175` stays completely untouched — only the data-fetching call at line 111 changes. On the frontend, `invoiceService.exportInvoices` in `client/src/modules/invoices/services/invoiceService.ts:89-103` uses a plain `axios.get` with `params`; the params object is simply removed. The `handleExportToExcel` handler in `InvoiceManagementPage.tsx:262-283` already captures `isExporting` state and blob download logic — only the call arguments at line 265 change.

## Implementation Order

1. **Task 1** — Add `findAllForExport` to the repository (no prerequisites).
2. **Task 2** — Update `IInvoiceService` interface signature (no prerequisites).
3. **Task 3** — Update `InvoiceService.exportToExcel` to use the new repository method (requires Task 1 and Task 2).
4. **Task 4** — Update `InvoiceController.exportToExcel` to drop pagination params (requires Task 2 and Task 3).
5. **Task 5** — Update `invoiceService.exportInvoices` on the frontend to remove params (no backend prerequisites, can run in parallel with Tasks 1–4).
6. **Task 6** — Update `handleExportToExcel` in `InvoiceManagementPage.tsx` to call `exportInvoices()` with no arguments (requires Task 5).

---

## Task 1: Add `findAllForExport` method to the invoice repository

**Files:**
- Modify: `api/src/application/repositories/invoice.repository.ts`

**Why:** The existing `findAll` method (line 15) unconditionally applies `skip`/`take` for pagination, an optional `WHERE status` clause, and a default `WHERE isArchived = false` guard. None of these should apply to the export path. A dedicated method keeps the paginated list behaviour untouched while giving the service a clean way to retrieve every tenant invoice.

- [ ] **Step 1: Add `findAllForExport` after the `findAll` method**

Locate the `findAll` method (ends at line 42). Insert the new method directly below it. It queries the same `Invoice` entity scoped only to `tenantId`, with no `skip`/`take`, no status clause, and no archived filter — returning `Invoice[]` (not a tuple, since count is not needed for export).

```typescript
async findAllForExport(tenantId: string): Promise {
return this.invoiceRepository.find({
where: { tenantId },
order: {
issueDate: 'DESC',
},
});
}
```

Key points: No `skip`, `take`, or `where.status` / `where.isArchived` — intentional. `order` by `issueDate DESC` matches the existing list behaviour for a consistent export experience.

---

## Task 2: Update `IInvoiceService` interface — remove `paginationParams` from `exportToExcel`

**Files:**
- Modify: `api/src/application/invoices/interfaces/invoice.service.interface.ts`

**Why:** The interface at line 19 declares `exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise`. Once the service implementation no longer accepts pagination params, the interface must match or TypeScript will reject the change.

- [ ] **Step 1: Replace the `exportToExcel` signature in the interface**

Locate line 19 in the interface body and replace the method signature to remove the second parameter.

```typescript
// before
exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise;

// after
exportToExcel(tenantId: string): Promise;
```

Imports: Remove `PaginationParamsDto` from the import on line 3 **only if** it is no longer referenced elsewhere in this file. After the change `PaginationParamsDto` is used only by `findAll` — it is still needed. No import change required.

---

## Task 3: Update `InvoiceService.exportToExcel` to fetch all invoices

**Files:**
- Modify: `api/src/application/invoices/invoice.service.ts`

**Why:** `exportToExcel` at line 107 currently accepts `paginationParams` and passes it to `this.invoiceRepository.findAll(tenantId, paginationParams)` (line 111), which returns a paginated, possibly filtered slice. Replacing this call with `findAllForExport(tenantId)` eliminates the pagination and filtering constraints.

- [ ] **Step 1: Remove `paginationParams` from the method signature and update the repository call**

Locate the `exportToExcel` method signature (line 107–110) and the repository call (line 111). Replace both.

```typescript
// before
async exportToExcel(
tenantId: string,
paginationParams: PaginationParamsDto,
): Promise {
const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);

// after
async exportToExcel(tenantId: string): Promise {
const invoices = await this.invoiceRepository.findAllForExport(tenantId);
```

Key points: The destructuring `const [invoices]` is dropped because `findAllForExport` returns `Invoice[]` directly, not a tuple. Everything below line 111 (workbook construction, column definitions, row loop, buffer generation) is unchanged.

Imports: `PaginationParamsDto` is still imported and used by `findAll` on line 22 — do **not** remove it.

---

## Task 4: Update `InvoiceController.exportToExcel` — strip pagination query params

**Files:**
- Modify: `api/src/api/controllers/invoice.controller.ts`

**Why:** The controller handler at line 221 accepts `@Query() paginationParams: PaginationParamsDto` and forwards it to the service. With the service signature changed, this parameter and its associated Swagger decorators must be removed. The three `@ApiQuery` decorators for `page`, `limit`, and `status` on the export endpoint (lines 197–214) also become incorrect — they advertise parameters that the endpoint no longer honours.

- [ ] **Step 1: Remove the three `@ApiQuery` decorators from the export endpoint**

Locate the block of three `@ApiQuery(...)` decorators above the `exportToExcel` handler (lines 197–214) and delete them. The `@ApiOperation`, `@ApiResponse`, and `@ApiUnauthorizedResponse` / `@ApiForbiddenResponse` decorators stay in place.

```typescript
// Remove these three blocks entirely:
@ApiQuery({
name: 'page',
required: false,
type: Number,
description: 'Page number (starts from 1)',
})
@ApiQuery({
name: 'limit',
required: false,
type: Number,
description: 'Number of items per page',
})
@ApiQuery({
name: 'status',
required: false,
enum: ['PAID', 'UNPAID', 'OVERDUE'],
description: 'Filter invoices by status',
})
```

- [ ] **Step 2: Remove `paginationParams` parameter and update the service call**

In the `exportToExcel` handler method signature (line 221–225), remove `@Query() paginationParams: PaginationParamsDto` and update the service call on line 227 to pass only `tenantId`.

```typescript
// before
async exportToExcel(
@Req() request: RequestWithTenant,
@Res() response: Response,
@Query() paginationParams: PaginationParamsDto,
): Promise {
const tenantId = request.tenantId!;
const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);

// after
async exportToExcel(
@Req() request: RequestWithTenant,
@Res() response: Response,
): Promise {
const tenantId = request.tenantId!;
const buffer = await this.invoiceService.exportToExcel(tenantId);
```

Imports: `PaginationParamsDto` is still used by the `findAll` handler (`@Query() paginationParams: PaginationParamsDto` at line 104) — do **not** remove the import. `ApiQuery` decorator is still used by the `findAll` endpoint — do **not** remove it either.

---

## Task 5: Update frontend `invoiceService.exportInvoices` to send no params

**Files:**
- Modify: `client/src/modules/invoices/services/invoiceService.ts`

**Why:** `exportInvoices` at line 89 currently accepts `page`, `limit`, and `status` and appends them as query parameters to `GET /invoices/export/excel`. The backend endpoint no longer reads these params. Removing them from the frontend service keeps the API surface clean and prevents sending unused query strings.

- [ ] **Step 1: Replace the `exportInvoices` function to remove all parameters and the params object**

Locate the `exportInvoices` function (lines 89–103) and replace it with a parameter-free version.

```typescript
/**
* Export all invoices to Excel file (tenant-scoped, no filters applied)
* @returns Promise
*/
exportInvoices: async (): Promise => {
const response = await axios.get('/invoices/export/excel', {
responseType: 'blob',
});
return response.data;
},
```

Key points: The `params` option is removed entirely — no `page`, `limit`, or `status` is sent. `responseType: 'blob'` is preserved unchanged.

---

## Task 6: Update `InvoiceManagementPage` — call `exportInvoices()` with no arguments

**Files:**
- Modify: `client/src/modules/invoices/components/InvoiceManagementPage.tsx`

**Why:** `handleExportToExcel` at line 265 calls `invoiceService.exportInvoices(page, limit, statusFilter || undefined)`. After Task 5 the function signature accepts no arguments; passing them would be a TypeScript error. The `isExporting` state, blob download, and cleanup logic (lines 263–282) are correct and remain unchanged.

- [ ] **Step 1: Remove the arguments from the `exportInvoices` call**

Locate `handleExportToExcel` (line 262) and update the single call to `exportInvoices`.

```typescript
// before
const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);

// after
const blob = await invoiceService.exportInvoices();
```

Key points: `page`, `limit`, and `statusFilter` state variables are still used elsewhere in the component (for the paginated list view) — do **not** remove them. Only this one call site changes.