### PR TITLE
IA-516 Resolve issue with an export to Excel on invoices page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -192,25 +192,7 @@ export class InvoiceController {
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
         summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
-    })
-    @ApiQuery({
-        name: 'status',
-        required: false,
-        enum: ['PAID', 'UNPAID', 'OVERDUE'],
-        description: 'Filter invoices by status',
+        description: 'Exports all non-archived invoices for the tenant to an Excel file',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -221,10 +203,9 @@ export class InvoiceController {
     async exportToExcel(
         @Req() request: RequestWithTenant,
         @Res() response: Response,
-        @Query() paginationParams: PaginationParamsDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        const buffer = await this.invoiceService.exportToExcel(tenantId);
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -16,7 +16,7 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    exportToExcel(tenantId: string): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -106,9 +106,8 @@ export class InvoiceService implements IInvoiceService {
 
     async exportToExcel(
         tenantId: string,
-        paginationParams: PaginationParamsDto,
     ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+        const invoices = await this.invoiceRepository.findAllForExport(tenantId);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -41,6 +41,15 @@ export class InvoiceRepository {
         });
     }
 
+    async findAllForExport(tenantId: string): Promise<Invoice[]> {
+        return this.invoiceRepository.find({
+            where: { tenantId, isArchived: false },
+            order: {
+                issueDate: 'DESC',
+            },
+        });
+    }
+
     async findById(id: string, tenantId: string): Promise<Invoice | null> {
         return this.invoiceRepository.findOne({
             where: { id, tenantId },

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -262,7 +262,7 @@ const InvoiceManagementPage: React.FC = () => {
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      const blob = await invoiceService.exportInvoices();
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,23 +80,11 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
-   * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * Export all non-archived invoices to Excel file
    * @returns Promise<Blob>
    */
-  exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
-    status?: string,
-  ): Promise<Blob> => {
+  exportInvoices: async (): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
-      params: {
-        page,
-        limit,
-        ...(status && { status }),
-      },
       responseType: 'blob',
     });
     return response.data;


### PR DESCRIPTION
Implementation of IA-516

Currently, when a user tries to export invoices, only the invoices visible on a page are exported.
Expected result: all invoices, regardless of pagination and filtering, must be exported

# Plan: IA-516 — Export All Invoices Regardless of Pagination and Filtering

## Context

Today the invoice export flow passes the current page's pagination state (`page`, `limit`, `status`) from the client all the way to the repository, where `skip`/`take` constrains the query to only the visible page. As a result, clicking "Export to Excel" downloads only the invoices the user currently sees. The fix removes pagination and filter parameters from the entire export code path — client call, API endpoint, service, and repository — so every non-archived invoice for the tenant is included in the Excel file.

**Decisions:**
- **"Regardless of filtering" means ignore status filter too** — the ticket literally says "regardless of pagination and filtering," so the export will fetch all invoices irrespective of the active status filter. This matches the expected behavior of a full data export.
- **Add a dedicated `findAllForExport` repository method** — avoids mutating the existing `findAll` which still needs pagination for the list view. Keeps concerns cleanly separated.
- **Keep excluding archived invoices by default** — the ticket does not mention archived invoices, and the current default (`isArchived = false`) is the safe choice for a bulk export.
- **Update the service interface to remove `paginationParams` from `exportToExcel`** — the export no longer needs any query parameters; the method signature should reflect that.
- **No new dependencies** — all changes use existing TypeORM, ExcelJS, and axios patterns already in the codebase.

## Stack already available (no new deps)

The implementation reuses TypeORM's `Repository.find()` (used throughout `api/src/application/repositories/invoice.repository.ts`), the ExcelJS workbook generation already in `InvoiceService.exportToExcel` (`api/src/application/invoices/invoice.service.ts:107-175`), and the axios-based `invoiceService` client helper (`client/src/modules/invoices/services/invoiceService.ts`). No new libraries or utilities are needed.

## Implementation Order

1. **Task 1: Add `findAllForExport` repository method** — no prerequisites
2. **Task 2: Update service interface and service to use unpaginated export** — requires Task 1
3. **Task 3: Simplify the API controller export endpoint** — requires Task 2
4. **Task 4: Remove pagination params from client export call** — requires Task 3

## Task 1: Add `findAllForExport` repository method

**Files:**
- Modify: `api/src/application/repositories/invoice.repository.ts`

**Why:** The existing `findAll` method (`invoice.repository.ts:15-42`) always applies `skip`/`take` pagination, which limits the export to one page of results. A dedicated method that queries all non-archived invoices without pagination is needed so the export service can retrieve the full dataset while leaving the paginated list view untouched.

- [ ] **Step 1: Add `findAllForExport` method to `InvoiceRepository`**

Add a new public method after the existing `findAll` method (after line 42). It accepts only `tenantId`, queries all non-archived invoices ordered by `issueDate DESC`, and returns the full array without count (since pagination metadata is irrelevant for export).

```typescript
// api/src/application/repositories/invoice.repository.ts
// ... after findAll method (line 42)

async findAllForExport(tenantId: string): Promise {
return this.invoiceRepository.find({
where: { tenantId, isArchived: false },
order: {
issueDate: 'DESC',
},
});
}
```

Key points: Uses `find()` instead of `findAndCount()` since total count is not needed. Hardcodes `isArchived: false` — archived invoices are excluded by design. No `skip`/`take` means all matching rows are returned.

## Task 2: Update service interface and service to use unpaginated export

**Files:**
- Modify: `api/src/application/invoices/interfaces/invoice.service.interface.ts`
- Modify: `api/src/application/invoices/invoice.service.ts`

**Why:** The `exportToExcel` method in both the interface (`invoice.service.interface.ts:19`) and the service (`invoice.service.ts:107-110`) currently accept `PaginationParamsDto` and pass it to `invoiceRepository.findAll()`, which applies pagination. Removing the pagination parameter and switching to the new `findAllForExport` repository method ensures the export retrieves all invoices.

- [ ] **Step 1: Remove `paginationParams` from the `IInvoiceService.exportToExcel` signature**

In the interface file, change the `exportToExcel` method signature to accept only `tenantId`.

```typescript
// api/src/application/invoices/interfaces/invoice.service.interface.ts
// Replace line 19:
exportToExcel(tenantId: string): Promise;
```

Imports: Remove `PaginationParamsDto` from the import on line 3 if it is no longer used in this file. Check: `findAll` on line 10 still uses it, so the import stays. No import changes needed.

- [ ] **Step 2: Update `InvoiceService.exportToExcel` to call `findAllForExport`**

In the service implementation, change the `exportToExcel` method to drop the `paginationParams` parameter and call `this.invoiceRepository.findAllForExport(tenantId)` instead of `this.invoiceRepository.findAll(tenantId, paginationParams)`.

```typescript
// api/src/application/invoices/invoice.service.ts
// Replace lines 107-111:
async exportToExcel(
tenantId: string,
): Promise {
const invoices = await this.invoiceRepository.findAllForExport(tenantId);
// ... rest of the method (workbook creation) remains unchanged
```

Key points: The destructured `[invoices]` on old line 111 changes to a plain assignment since `findAllForExport` returns `Invoice[]` not `[Invoice[], number]`. The rest of the method body (lines 113-175) is unchanged — it iterates `invoices` the same way.

## Task 3: Simplify the API controller export endpoint

**Files:**
- Modify: `api/src/api/controllers/invoice.controller.ts`

**Why:** The `exportToExcel` controller method (`invoice.controller.ts:221-232`) currently injects `@Query() paginationParams: PaginationParamsDto` and forwards it to the service. Since the service no longer accepts pagination params, the controller must stop accepting and passing them. The Swagger `@ApiQuery` decorators for `page`, `limit`, and `status` on lines 197-214 should also be removed to keep the API documentation accurate.

- [ ] **Step 1: Remove pagination-related `@ApiQuery` decorators from the export endpoint**

Remove the three `@ApiQuery` decorators for `page`, `limit`, and `status` above the `exportToExcel` method (lines 197-214).

```typescript
// api/src/api/controllers/invoice.controller.ts
// Lines 191-220 become:
@Get('export/excel')
@Authorize(RoleName.SUPER_ADMIN)
@ApiOperation({
summary: 'Export invoices to Excel',
description: 'Exports all invoices to an Excel file',
})
@ApiResponse({
status: HttpStatus.OK,
description: 'Excel file generated successfully',
})
@ApiUnauthorizedResponse({ description: 'Unauthorized' })
@ApiForbiddenResponse({ description: 'Forbidden - requires SUPER_ADMIN role' })
```

- [ ] **Step 2: Remove `paginationParams` from the `exportToExcel` method signature and call**

Update the method to no longer accept `@Query() paginationParams` and call `this.invoiceService.exportToExcel(tenantId)` without pagination params.

```typescript
// api/src/api/controllers/invoice.controller.ts
// Replace lines 221-232:
async exportToExcel(
@Req() request: RequestWithTenant,
@Res() response: Response,
): Promise {
const tenantId = request.tenantId!;
const buffer = await this.invoiceService.exportToExcel(tenantId);

response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);
response.send(buffer);
}
```

Imports: Check whether `PaginationParamsDto` is still imported elsewhere in this file. It is used by `findAll` on line 104, so the import on line 37-38 stays. No import changes needed.

## Task 4: Remove pagination params from client export call

**Files:**
- Modify: `client/src/modules/invoices/services/invoiceService.ts`
- Modify: `client/src/modules/invoices/components/InvoiceManagementPage.tsx`

**Why:** The client-side `exportInvoices` function (`invoiceService.ts:89-103`) sends `page`, `limit`, and `status` as query params to `GET /invoices/export/excel`. The `handleExportToExcel` handler in `InvoiceManagementPage.tsx:262-265` passes the current pagination state. Since the API no longer accepts these parameters, the client must stop sending them.

- [ ] **Step 1: Simplify `exportInvoices` in `invoiceService.ts`**

Remove the `page`, `limit`, and `status` parameters from the function signature and the `params` object in the axios call.

```typescript
// client/src/modules/invoices/services/invoiceService.ts
// Replace lines 82-103:
/**
* Export invoices to Excel file
* @returns Promise
*/
exportInvoices: async (): Promise => {
const response = await axios.get('/invoices/export/excel', {
responseType: 'blob',
});
return response.data;
},
```

- [ ] **Step 2: Update `handleExportToExcel` in `InvoiceManagementPage.tsx`**

Remove the arguments passed to `invoiceService.exportInvoices()` so it calls the parameterless version.

```typescript
// client/src/modules/invoices/components/InvoiceManagementPage.tsx
// Replace line 265:
const blob = await invoiceService.exportInvoices();
```

Key points: No other changes needed in this file — the `isExporting` state, download link creation, and error handling on lines 263-283 all remain as-is.