### PR TITLE
IA-519 add reset password option in the user profile menu

### DIFF
--- a/client/src/common/components/CustomUserButton.tsx
+++ b/client/src/common/components/CustomUserButton.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import LogoutIcon from '@mui/icons-material/Logout';
+import VpnKeyIcon from '@mui/icons-material/VpnKey';
 import { useClerk, useUser } from '@clerk/clerk-react';
 
 type CustomUserButtonProps = {
@@ -24,7 +25,7 @@ type CustomUserButtonProps = {
 const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
   const buttonRef = useRef<HTMLDivElement>(null);
-  const { signOut } = useClerk();
+  const { signOut, openUserProfile } = useClerk();
   const { user } = useUser();
   const theme = useTheme();
 
@@ -47,7 +48,14 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
     handleClose();
   };
 
+  const handleResetPassword = (): void => {
+    handleClose();
+    openUserProfile();
+  };
+
   const open = Boolean(anchorEl);
+  // Clerk sets passwordEnabled to false for OAuth-only / email-code-only accounts
+  const canResetPassword = user?.passwordEnabled ?? false;
 
   return (
     <>
@@ -155,6 +163,35 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
               </ListItemIcon>
               <ListItemText primary="Manage account" />
             </ListItemButton>
+          </ListItem>
+
+          <ListItem disablePadding>
+            <Tooltip
+              title={
+                !canResetPassword
+                  ? 'Password reset is not available for accounts using social login or email code'
+                  : ''
+              }
+              placement="left">
+              {/* span wrapper ensures the Tooltip works even when the button is disabled */}
+              <span style={{ width: '100%' }}>
+                <ListItemButton
+                  onClick={handleResetPassword}
+                  disabled={!canResetPassword}
+                  sx={{
+                    px: 2,
+                    width: '100%',
+                    '&:hover': {
+                      backgroundColor: theme.palette.action.hover,
+                    },
+                  }}>
+                  <ListItemIcon sx={{ minWidth: 36, color: theme.palette.primary.main }}>
+                    <VpnKeyIcon fontSize="small" />
+                  </ListItemIcon>
+                  <ListItemText primary="Reset password" />
+                </ListItemButton>
+              </span>
+            </Tooltip>
           </ListItem>
 
           <ListItem disablePadding>


### PR DESCRIPTION
Implementation of IA-519

add reset password option in the user profile menu

# Plan: Add "Reset password" option to the user profile menu

## Context
The user profile menu lives in `client/src/common/components/CustomUserButton.tsx` — a custom MUI `Popover` containing a header (avatar + email) and a `List` of `ListItemButton` rows ("Manage account" stub and "Sign out"). The task adds a third row, "Reset password", that opens Clerk's built-in account/security modal via `useClerk().openUserProfile()`. For accounts without a password (OAuth-only / email-code-only), the row must be disabled. Both `useClerk()` and `useUser()` are already imported and destructured in this file, so the wiring reuses existing hooks with no new dependencies.

Decisions:
- Open Clerk's prebuilt modal via `openUserProfile()` — explicitly chosen behavior.
- Pull `openUserProfile` from the existing `useClerk()` destructure — hook already in file.
- Detect passwordless accounts via `user?.passwordEnabled` — standard Clerk user field.
- Disable (not hide) the row for passwordless accounts — explicit requirement.
- Use MUI `` to explain the disabled state — `Tooltip` already imported.
- Use `VpnKeyIcon` for the row icon — matches MUI icon convention already used (`SettingsIcon`, `LogoutIcon`).
- Place the row between "Manage account" and "Sign out" — keeps "Sign out" last, mirroring existing ordering.

## Stack already available (no new deps)
Reuses `@clerk/clerk-react`'s `useClerk()` (already imported, `CustomUserButton.tsx:27`) and `useUser()` (`:28`). The new row mirrors the existing `ListItem` / `ListItemButton` / `ListItemIcon` / `ListItemText` shape at `CustomUserButton.tsx:144-158`, the same `sx` hover styling, and `theme.palette.*` colors. `Tooltip` is already imported (`:13`) and used at `:123`. Icons follow the existing `@mui/icons-material/*` import pattern (`SettingsIcon` `:16`, `LogoutIcon` `:17`); add `VpnKeyIcon` the same way.

## Implementation Order
1. Task 1 — Wire up Clerk modal trigger + passwordless detection and render the "Reset password" row in `CustomUserButton.tsx`. (No prerequisites; single-file change.)

## Task 1: Add a "Reset password" menu row that opens Clerk's account modal, disabled for passwordless accounts

**Files:**
- Modify: `client/src/common/components/CustomUserButton.tsx`

**Why:** The profile menu currently exposes only "Manage account" (a no-op stub at `:46-48`) and "Sign out". There is no way for a user to reset/change their password from the menu. This Task adds the missing entry, hooks it to Clerk's built-in security UI, and prevents misuse on accounts that have no password to reset.

- [ ] **Step 1: Import the key icon and destructure `openUserProfile`/`user` for the new behavior.**

Add the `VpnKeyIcon` import alongside the existing icon imports, and pull `openUserProfile` out of the already-present `useClerk()` call. `user` is already destructured from `useUser()` (`:28`) and is reused for `passwordEnabled`.

```tsx
import LogoutIcon from '@mui/icons-material/Logout';
import VpnKeyIcon from '@mui/icons-material/VpnKey';
// ...
const { signOut, openUserProfile } = useClerk();
const { user } = useUser();
```

Imports: `VpnKeyIcon` from `@mui/icons-material/VpnKey`.
Key points: Do not add a second `useClerk()`/`useUser()` call — extend the existing destructures.

- [ ] **Step 2: Add a handler that closes the popover and opens Clerk's account modal.**

Next to the existing `handleManageAccount` (`:46-48`), add `handleResetPassword`. It mirrors the close-then-act pattern of `handleSignOut` (`:39-44`): close the popover first, then invoke `openUserProfile()` so Clerk's modal isn't rendered behind the popover.

```tsx
const handleResetPassword = (): void => {
handleClose();
openUserProfile();
};
```

Key points: Call `handleClose()` before `openUserProfile()` so the popover is dismissed before the modal opens.

- [ ] **Step 3: Compute a passwordless flag for the disabled state.**

Before the `return`, derive whether the account supports password reset. Clerk sets `user.passwordEnabled` to `false` for OAuth-only / email-code-only accounts. Treat a missing/falsey value as passwordless so the row defaults to disabled until Clerk confirms a password exists.

```tsx
const open = Boolean(anchorEl);
const canResetPassword = Boolean(user?.passwordEnabled);
```

Key points: Place this alongside the existing `open` constant (`:50`).

- [ ] **Step 4: Render the "Reset password" row between "Manage account" and "Sign out".**

Insert a new `ListItem` after the "Manage account" `ListItem` (closes at `:158`) and before the "Sign out" `ListItem` (`:160`). Mirror the existing row markup (same `sx`, `ListItemIcon`, `ListItemText`). Set `disabled={!canResetPassword}` on the `ListItemButton`, and wrap it in a `Tooltip` explaining the disabled case. Because MUI disabled buttons don't fire pointer events, the `Tooltip` wraps a `` so the tooltip still shows.

```tsx

```

Key points: The `` keeps the row full-width and lets the `Tooltip` work over a disabled control (a disabled MUI button swallows hover events). An empty `title` renders no tooltip when the row is enabled. Keep this row above the "Sign out" `ListItem` so "Sign out" remains the last entry.