### PR TITLE
IA-521 Resolve the issue with export to Excel on the invoices page

### DIFF
--- a/api/src/api/controllers/invoice.controller.ts
+++ b/api/src/api/controllers/invoice.controller.ts
@@ -192,25 +192,7 @@ export class InvoiceController {
     @Authorize(RoleName.SUPER_ADMIN)
     @ApiOperation({
         summary: 'Export invoices to Excel',
-        description: 'Exports all invoices to an Excel file based on pagination and filters',
-    })
-    @ApiQuery({
-        name: 'page',
-        required: false,
-        type: Number,
-        description: 'Page number (starts from 1)',
-    })
-    @ApiQuery({
-        name: 'limit',
-        required: false,
-        type: Number,
-        description: 'Number of items per page',
-    })
-    @ApiQuery({
-        name: 'status',
-        required: false,
-        enum: ['PAID', 'UNPAID', 'OVERDUE'],
-        description: 'Filter invoices by status',
+        description: 'Exports ALL invoices for the tenant to an Excel file, ignoring pagination and all filters (including archived invoices)',
     })
     @ApiResponse({
         status: HttpStatus.OK,
@@ -221,10 +203,9 @@ export class InvoiceController {
     async exportToExcel(
         @Req() request: RequestWithTenant,
         @Res() response: Response,
-        @Query() paginationParams: PaginationParamsDto,
     ): Promise<void> {
         const tenantId = request.tenantId!;
-        const buffer = await this.invoiceService.exportToExcel(tenantId, paginationParams);
+        const buffer = await this.invoiceService.exportToExcel(tenantId);
 
         response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
         response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);

--- a/api/src/application/invoices/interfaces/invoice.service.interface.ts
+++ b/api/src/application/invoices/interfaces/invoice.service.interface.ts
@@ -16,7 +16,7 @@ export interface IInvoiceService {
 
     remove(id: string, tenantId: string): Promise<void>;
 
-    exportToExcel(tenantId: string, paginationParams: PaginationParamsDto): Promise<Buffer>;
+    exportToExcel(tenantId: string): Promise<Buffer>;
 
     archiveInvoices(ids: string[], tenantId: string): Promise<void>;
 

--- a/api/src/application/invoices/invoice.service.ts
+++ b/api/src/application/invoices/invoice.service.ts
@@ -104,11 +104,8 @@ export class InvoiceService implements IInvoiceService {
         await this.invoiceRepository.remove(id, tenantId);
     }
 
-    async exportToExcel(
-        tenantId: string,
-        paginationParams: PaginationParamsDto,
-    ): Promise<Buffer> {
-        const [invoices] = await this.invoiceRepository.findAll(tenantId, paginationParams);
+    async exportToExcel(tenantId: string): Promise<Buffer> {
+        const invoices = await this.invoiceRepository.findAllForExport(tenantId);
 
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('Invoices');

--- a/api/src/application/repositories/invoice.repository.ts
+++ b/api/src/application/repositories/invoice.repository.ts
@@ -41,6 +41,15 @@ export class InvoiceRepository {
         });
     }
 
+    async findAllForExport(tenantId: string): Promise<Invoice[]> {
+        return this.invoiceRepository.find({
+            where: { tenantId },
+            order: {
+                issueDate: 'DESC',
+            },
+        });
+    }
+
     async findById(id: string, tenantId: string): Promise<Invoice | null> {
         return this.invoiceRepository.findOne({
             where: { id, tenantId },

--- a/client/src/modules/invoices/components/InvoiceManagementPage.tsx
+++ b/client/src/modules/invoices/components/InvoiceManagementPage.tsx
@@ -262,7 +262,7 @@ const InvoiceManagementPage: React.FC = () => {
   const handleExportToExcel = async () => {
     setIsExporting(true);
     try {
-      const blob = await invoiceService.exportInvoices(page, limit, statusFilter || undefined);
+      const blob = await invoiceService.exportInvoices();
 
       // Create download link
       const url = window.URL.createObjectURL(blob);

--- a/client/src/modules/invoices/services/invoiceService.ts
+++ b/client/src/modules/invoices/services/invoiceService.ts
@@ -80,23 +80,12 @@ export const invoiceService = {
   },
 
   /**
-   * Export invoices to Excel file
-   * @param page - Page number (starts at 1)
-   * @param limit - Number of items per page
-   * @param status - Optional status filter (PAID, UNPAID, OVERDUE)
+   * Export ALL invoices to Excel file.
+   * Exports every invoice for the tenant regardless of pagination, status, or archived state.
    * @returns Promise<Blob>
    */
-  exportInvoices: async (
-    page: number = 1,
-    limit: number = 10,
-    status?: string,
-  ): Promise<Blob> => {
+  exportInvoices: async (): Promise<Blob> => {
     const response = await axios.get('/invoices/export/excel', {
-      params: {
-        page,
-        limit,
-        ...(status && { status }),
-      },
       responseType: 'blob',
     });
     return response.data;


### PR DESCRIPTION
Implementation of IA-521

Currently, when a user tries to export invoices, only the invoices visible on a page are exported.
Expected result: all invoices, regardless of pagination and filtering, must be exported

# Plan: Export ALL invoices (ignore pagination + all filters)

## Context
Today the "Export to Excel" feature only exports the rows on the current page: `InvoiceService.exportToExcel` calls `invoiceRepository.findAll(tenantId, paginationParams)`, which applies `skip`/`take`, an optional `status` filter, and excludes archived invoices (`invoice.repository.ts:34-41`). The fix is to fetch the **entire** invoice set for the tenant — no pagination, no status filter, archived included — and build the existing ExcelJS workbook from all rows, returned synchronously. Per the resolved scope ("yes ignore all filters", "single synchronous download is fine"), the export must contain every invoice for the tenant regardless of UI state.

Decisions:
- New repository method `findAllForExport(tenantId)` — explicit intent, no flag-overloading of `findAll`.
- `where: { tenantId }` only — no status, no `isArchived`, no `skip`/`take` (ignores all filters).
- Keep `order: { issueDate: 'DESC' }` — mirror existing list ordering.
- Drop `paginationParams` from `exportToExcel` (service + interface + controller) — params no longer meaningful.
- Frontend `exportInvoices()` takes no args; remove query params from the request.
- Synchronous Blob download flow unchanged — no streaming/async.

## Stack already available (no new deps)
TypeORM `Repository` (`invoice.repository.ts`), ExcelJS workbook building already implemented in `InvoiceService.exportToExcel` (`invoice.service.ts:107-175`), NestJS controller with `@Res()` Blob streaming (`invoice.controller.ts:221-232`), and the frontend `axios` service with `responseType: 'blob'` (`invoiceService.ts:89-103`). No new libraries, DTOs, or patterns are introduced — only the data-fetch query is broadened and now-unused params are removed.

## Implementation Order
1. Task 1: Add `findAllForExport` to `InvoiceRepository` (no prerequisites).
2. Task 2: Update `InvoiceService.exportToExcel` to use it and drop pagination param (requires Task 1).
3. Task 3: Update `IInvoiceService.exportToExcel` signature (aligns with Task 2).
4. Task 4: Update controller `exportToExcel` to drop query params + Swagger docs (requires Tasks 2-3).
5. Task 5: Update frontend `invoiceService.exportInvoices` to take no args (independent of backend).
6. Task 6: Update `handleExportToExcel` call site (requires Task 5).

---

## Task 1: Add `findAllForExport` to the invoice repository

**Files:**
- Modify: `api/src/application/repositories/invoice.repository.ts`

**Why:** The only data source for export is `findAll`, which hard-applies `skip`/`take`, optional `status`, and `isArchived: false` (`invoice.repository.ts:19-41`). That is the root cause of "only the current page is exported." A dedicated method that filters by `tenantId` alone returns the full set the export requires.

- [ ] **Step 1: Add the `findAllForExport` method**

Insert a new method right after `findAll` (ends at line 42). It queries by `tenantId` only — no pagination, no status, archived included — and reuses the same `issueDate DESC` ordering as the list. Return `Invoice[]` (no count needed for export).

```ts
// ... after findAll() closing brace (line 42)
async findAllForExport(tenantId: string): Promise {
return this.invoiceRepository.find({
where: { tenantId },
order: {
issueDate: 'DESC',
},
});
}
```

Key points: deliberately omit `skip`/`take`/`status`/`isArchived` so every invoice for the tenant is returned. No new imports — `Invoice` and `Repository` are already imported.

---

## Task 2: Make `exportToExcel` build the workbook from all invoices

**Files:**
- Modify: `api/src/application/invoices/invoice.service.ts`

**Why:** `exportToExcel` currently fetches a single paginated/filtered page via `this.invoiceRepository.findAll(tenantId, paginationParams)` (`invoice.service.ts:111`). It must instead pull the full set. The `paginationParams` argument becomes dead weight and is removed.

- [ ] **Step 1: Replace the paginated fetch and drop the unused param**

Change the method signature to take only `tenantId`, and replace the `findAll` call with `findAllForExport`. The rest of the workbook-building body (columns, header styling, `invoices.forEach`, `writeBuffer`) is unchanged.

```ts
async exportToExcel(tenantId: string): Promise {
const invoices = await this.invoiceRepository.findAllForExport(tenantId);

const workbook = new ExcelJS.Workbook();
// ... unchanged: worksheet columns, header styling, invoices.forEach, writeBuffer
```

Key points: `findAll` returned a tuple `[invoices]`; `findAllForExport` returns a plain array, so drop the array-destructuring. `PaginationParamsDto` is still imported and used by `findAll`/the `findAll` service method — leave that import in place.

---

## Task 3: Update the service interface signature

**Files:**
- Modify: `api/src/application/invoices/interfaces/invoice.service.interface.ts`

**Why:** `IInvoiceService.exportToExcel` declares `(tenantId, paginationParams)` (`invoice.service.interface.ts:19`). After Task 2 the implementation no longer accepts `paginationParams`, so the interface must match or TypeScript will error.

- [ ] **Step 1: Remove `paginationParams` from the interface method**

```ts
exportToExcel(tenantId: string): Promise;
```

Key points: `PaginationParamsDto` is still referenced by `findAll` in the same interface (line 8-11), so keep its import.

---

## Task 4: Update the controller endpoint and Swagger docs

**Files:**
- Modify: `api/src/api/controllers/invoice.controller.ts`

**Why:** The `GET /invoices/export/excel` handler reads `@Query() paginationParams` and forwards it to the service (`invoice.controller.ts:224-227`), and advertises `page`/`limit`/`status` query params plus a "based on pagination and filters" description (`invoice.controller.ts:193-214`). These no longer apply — the endpoint now always exports everything.

- [ ] **Step 1: Drop the query param from the handler and the service call**

Remove the `@Query() paginationParams` parameter and pass only `tenantId` to the service.

```ts
async exportToExcel(
@Req() request: RequestWithTenant,
@Res() response: Response,
): Promise {
const tenantId = request.tenantId!;
const buffer = await this.invoiceService.exportToExcel(tenantId);

response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
response.setHeader('Content-Disposition', `attachment; filename=invoices-${Date.now()}.xlsx`);
response.send(buffer);
}
```

- [ ] **Step 2: Update the Swagger description and remove the now-irrelevant `@ApiQuery` decorators**

Update the `@ApiOperation` description and delete the three `@ApiQuery` blocks (`page`, `limit`, `status`) above `exportToExcel` (`invoice.controller.ts:197-214`), since the endpoint ignores all filters/pagination.

```ts
@Get('export/excel')
@Authorize(RoleName.SUPER_ADMIN)
@ApiOperation({
summary: 'Export invoices to Excel',
description: 'Exports all invoices for the tenant to an Excel file, ignoring pagination and all filters (including archived)',
})
// removed: @ApiQuery page / limit / status
@ApiResponse({
status: HttpStatus.OK,
description: 'Excel file generated successfully',
})
// ... unchanged: @ApiUnauthorizedResponse, @ApiForbiddenResponse
```

Key points: `@Query` and `PaginationParamsDto` may remain imported — they are still used by the `findAll` handler (`invoice.controller.ts:104`). Do not remove those imports. `ApiQuery` is also still used by `findAll`, so keep its import too.

---

## Task 5: Update the frontend export service to take no arguments

**Files:**
- Modify: `client/src/modules/invoices/services/invoiceService.ts`

**Why:** `exportInvoices(page, limit, status?)` sends `page`/`limit`/`status` query params (`invoiceService.ts:89-103`). With the backend now ignoring them, the params are misleading and should be dropped so the call cleanly requests the full export.

- [ ] **Step 1: Remove params and send a plain blob request**

Replace the parameterized signature and request with an argument-less call. Update the JSDoc to drop the `@param` lines.

```ts
/**
* Export ALL invoices to an Excel file (ignores pagination and filters).
* @returns Promise
*/
exportInvoices: async (): Promise => {
const response = await axios.get('/invoices/export/excel', {
responseType: 'blob',
});
return response.data;
},
```

Key points: no `params` object is sent anymore. Other service methods are untouched.

---

## Task 6: Update the export button handler to call without args

**Files:**
- Modify: `client/src/modules/invoices/components/InvoiceManagementPage.tsx`

**Why:** `handleExportToExcel` passes `page, limit, statusFilter` into `exportInvoices` (`InvoiceManagementPage.tsx:265`). After Task 5 the function takes no args; the call must be updated to match and to reflect that the export is no longer scoped to the current view.

- [ ] **Step 1: Drop the arguments from the `exportInvoices` call**

```ts
const handleExportToExcel = async () => {
setIsExporting(true);
try {
const blob = await invoiceService.exportInvoices();
// ... unchanged: createObjectURL download logic
```

Key points: leave the surrounding download/blob logic and `isExporting` state handling unchanged. `page`, `limit`, and `statusFilter` are still used elsewhere on the page (list query), so do not remove those variables.