### PR TITLE
IA-523 Replace days overdue column value

### DIFF
--- a/client/src/modules/invoices/components/InvoiceTable.tsx
+++ b/client/src/modules/invoices/components/InvoiceTable.tsx
@@ -27,6 +27,7 @@ import {
   Visibility as ViewIcon,
   Delete as DeleteIcon,
   Archive as ArchiveIcon,
+  NotificationsActive as BellIcon,
 } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
 import { Invoice } from '../types/invoice';
@@ -221,50 +222,21 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({
     }
   };
 
-  // Format days overdue with visual alert for invoices overdue by more than 85 days
+  // Show a red bell icon when an invoice is overdue by at least 270 days; blank otherwise
   const formatDaysOverdue = (daysOverdue: number) => {
-    if (daysOverdue === 0) {
+    if (daysOverdue >= 270) {
+      const label = `Overdue by ${daysOverdue} days`;
       return (
-        <Typography color="text.secondary">
-          –
-        </Typography>
+        <Tooltip title={label}>
+          <BellIcon
+            aria-label={label}
+            sx={{ color: theme.palette.error.main }}
+          />
+        </Tooltip>
       );
     }
 
-    // Display invoices overdue by more than 85 days
-    if (daysOverdue > 85) {
-      return (
-        <Typography
-          fontWeight="medium"
-          sx={theme => ({
-            color: theme.palette.invoiceStatus.overdue,
-            backgroundColor: `${theme.palette.invoiceStatus.overdue}20`,
-            px: 1,
-            py: 0.5,
-            borderRadius: 1,
-            display: 'inline-block',
-          })}
-        >
-          {daysOverdue} days
-        </Typography>
-      );
-    }
-
-    return (
-      <Typography
-        fontWeight="medium"
-        sx={theme => ({
-          color: theme.palette.invoiceStatus.overdue,
-          backgroundColor: `${theme.palette.invoiceStatus.overdue}20`,
-          px: 1,
-          py: 0.5,
-          borderRadius: 1,
-          display: 'inline-block',
-        })}
-      >
-        {daysOverdue} days
-      </Typography>
-    );
+    return null;
   };
 
   // Calculate and display the status of an invoice


### PR DESCRIPTION
Implementation of IA-523

Replace the value with the red bell icon if overdue by at least 270 days (leave it blank if less).

# Plan: Days Overdue red bell icon at ≥270 days (IA-523)

## Context
The invoices table renders a "Days Overdue" column through the helper
`formatDaysOverdue` in `client/src/modules/invoices/components/InvoiceTable.tsx`
(lines ~224-268), invoked at the cell `{formatDaysOverdue(invoice.daysOverdue)}`
(line 505). The value (`invoice.daysOverdue`) is already computed server-side and
arrives on the client, so the threshold logic belongs in this render path, which
already contains threshold branches (`=== 0`, `> 85`). IA-523 changes the displayed
content: when an invoice is overdue by **at least 270 days**, the cell shows a **red
bell icon** instead of the day count; when it is overdue by less than 270 days, the
cell is **blank**.

- Decisions:
- Threshold is inclusive: `daysOverdue >= 270` → icon. (matches "at least 270")
- "Blank if less" means render `null` (empty cell), removing all prior text/styling. (literal reading)
- Use `NotificationsActive` from `@mui/icons-material`. (clearest bell glyph, dep already present)
- Color via `theme.palette.error.main` (literal red), not `invoiceStatus.overdue` (pink/lemon). (true red)
- Add `Tooltip` + `aria-label` describing the overdue alert. (accessibility, reuses imported `Tooltip`)
- Sorting is unaffected — it uses the numeric `daysOverdue` accessor, not the rendered node. (no change needed)

## Stack already available (no new deps)
Reuses Material UI primitives already imported in `InvoiceTable.tsx`: `Tooltip`
(line 10) and `useTheme` (line 31). Icons come from `@mui/icons-material` (^7.0.1),
already imported at lines 26-30 (extend that import with `NotificationsActive`).
Red is sourced from the active MUI theme via `theme.palette.error.main`, consistent
with overdue styling used elsewhere (`InvoiceDetails.tsx`). No new dependencies,
types, or files.

## Implementation Order
1. Task 1 — Add the `NotificationsActive` icon import. (no prerequisites)
2. Task 2 — Rewrite `formatDaysOverdue` to return the red bell at ≥270 days, else blank. (requires Task 1)

## Task 1: Import the bell icon glyph

**Files:**
- Modify: `client/src/modules/invoices/components/InvoiceTable.tsx`

**Why:** The cell must render a bell icon, but the current icon import block
(lines 26-30) only pulls `Visibility`, `Delete`, and `Archive`. Without adding the
glyph, Task 2's JSX would reference an undefined symbol.

- [ ] **Step 1: Add `NotificationsActive` to the `@mui/icons-material` import.**

Extend the existing named import from `@mui/icons-material` (lines 26-30) with the
bell glyph, aliased to a task-clear name `BellIcon`. Keep the existing aliases intact.

```tsx
import {
Visibility as ViewIcon,
Delete as DeleteIcon,
Archive as ArchiveIcon,
NotificationsActive as BellIcon,
} from '@mui/icons-material';
```

Imports: `NotificationsActive as BellIcon` from `@mui/icons-material`.

## Task 2: Show the red bell at ≥270 days, blank below

**Files:**
- Modify: `client/src/modules/invoices/components/InvoiceTable.tsx`

**Why:** The current `formatDaysOverdue` (lines 225-268) always renders the numeric
day count (with a `–` at `0` and a styled `> 85` branch). IA-523 requires the cell to
instead display only a red bell when `daysOverdue >= 270` and be empty otherwise.
Replacing the whole helper body is the correct minimal change because all existing
branches produce output that must no longer appear.

- [ ] **Step 1: Replace the body of `formatDaysOverdue` with the threshold + blank logic.**

Locate the helper at line 225. Replace its entire body (the `=== 0` branch, the
`> 85` branch, and the default `return`) with two outcomes: a red `BellIcon` wrapped
in a `Tooltip` when `daysOverdue >= 270`, and `null` otherwise. Update the leading
comment to describe the new behavior. Use `error.main` for the red color and give the
icon an `aria-label` for screen readers.

```tsx
// Show a red bell icon when an invoice is overdue by at least 270 days; blank otherwise
const formatDaysOverdue = (daysOverdue: number) => {
if (daysOverdue >= 270) {
return (

({ color: theme.palette.error.main })}
/>

);
}

return null;
};
```

Key points: the threshold is inclusive (`>= 270`); returning `null` yields an empty
`` (the cell wrapper at line 505 is unchanged). Do not touch the sort
comparator — it reads the numeric `invoice.daysOverdue`, so replacing the rendered
node with an icon/blank does not affect ordering.