### PR TITLE
IA-525 Replace the days overdue column value

### DIFF
--- a/client/src/modules/invoices/components/InvoiceTable.tsx
+++ b/client/src/modules/invoices/components/InvoiceTable.tsx
@@ -27,6 +27,7 @@ import {
   Visibility as ViewIcon,
   Delete as DeleteIcon,
   Archive as ArchiveIcon,
+  NotificationsActive as NotificationsActiveIcon,
 } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
 import { Invoice } from '../types/invoice';
@@ -221,50 +222,13 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({
     }
   };
 
-  // Format days overdue with visual alert for invoices overdue by more than 85 days
+  // Render a red bell icon for invoices overdue by at least 270 days; blank otherwise
   const formatDaysOverdue = (daysOverdue: number) => {
-    if (daysOverdue === 0) {
-      return (
-        <Typography color="text.secondary">
-          –
-        </Typography>
-      );
-    }
-
-    // Display invoices overdue by more than 85 days
-    if (daysOverdue > 85) {
-      return (
-        <Typography
-          fontWeight="medium"
-          sx={theme => ({
-            color: theme.palette.invoiceStatus.overdue,
-            backgroundColor: `${theme.palette.invoiceStatus.overdue}20`,
-            px: 1,
-            py: 0.5,
-            borderRadius: 1,
-            display: 'inline-block',
-          })}
-        >
-          {daysOverdue} days
-        </Typography>
-      );
-    }
-
-    return (
-      <Typography
-        fontWeight="medium"
-        sx={theme => ({
-          color: theme.palette.invoiceStatus.overdue,
-          backgroundColor: `${theme.palette.invoiceStatus.overdue}20`,
-          px: 1,
-          py: 0.5,
-          borderRadius: 1,
-          display: 'inline-block',
-        })}
-      >
-        {daysOverdue} days
-      </Typography>
-    );
+    return daysOverdue >= 270 ? (
+      <Tooltip title="Overdue by 270+ days">
+        <NotificationsActiveIcon sx={{ color: theme.palette.invoiceStatus.overdue }} />
+      </Tooltip>
+    ) : null;
   };
 
   // Calculate and display the status of an invoice


### PR DESCRIPTION
Implementation of IA-525

Replace the value with the red bell icon if overdue by at least 270 days (leave it blank if less).

# Plan: Red bell icon for invoices overdue by ≥ 270 days (IA-525)

## Context
The "Days Overdue" column in the invoices table is rendered by the local helper
`formatDaysOverdue` in `client/src/modules/invoices/components/InvoiceTable.tsx`
(defined at line 225, called at line 505). Today it has three branches: `=== 0`
renders a muted dash, `> 85` renders a highlighted `{daysOverdue} days` chip, and
the fallback also renders `{daysOverdue} days`. Per IA-525 the cell's content is
being redefined: render a **red bell icon** when `daysOverdue >= 270`, and render
**blank (nothing)** for every value below 270. The numeric `{daysOverdue} days`
display and the dash are replaced entirely by this new two-state behavior.

- Decisions:
- Icon: MUI `NotificationsActiveIcon` — matches "active alert" bell semantics.
- Red color: reuse `theme.palette.invoiceStatus.overdue` — existing overdue color in this fn.
- Threshold: `daysOverdue >= 270` ("at least 270") — literal ticket wording.
- Blank: `return null` — renders an empty cell, no placeholder.
- Replace all prior branches (dash, `>85`, fallback) — ticket says replace "the value".
- Wrap icon in `Tooltip` for accessible context — `Tooltip` already imported.

## Stack already available (no new deps)
Material UI is the component library. `@mui/icons-material` is already imported in
this file (`InvoiceTable.tsx:26-30`) for `ViewIcon`, `DeleteIcon`, `ArchiveIcon`;
`NotificationsActive` is part of the same package — add it to that import block.
`useTheme` is in scope and `theme.palette.invoiceStatus.overdue` is the established
overdue red (used at `InvoiceTable.tsx:240,257,286` and typed in
`client/src/themes/theme.d.ts:5`). `Tooltip` is already imported
(`InvoiceTable.tsx:10`). No new dependencies, no type changes.

## Implementation Order
1. Task 1 — Add the `NotificationsActive` icon import. (no prerequisites)
2. Task 2 — Rewrite `formatDaysOverdue` body. (requires Task 1 for the icon symbol)

## Task 1: Import the red bell icon

**Files:**
- Modify: `client/src/modules/invoices/components/InvoiceTable.tsx`

**Why:** The new behavior renders a bell icon, but only `ViewIcon`, `DeleteIcon`,
and `ArchiveIcon` are currently imported from `@mui/icons-material`
(`InvoiceTable.tsx:26-30`). Without adding the symbol the component cannot
reference the bell.

- [ ] **Step 1: Add `NotificationsActive` to the icon import block**

Locate the named import from `@mui/icons-material` at lines 26-30 and add a
`NotificationsActive` alias following the existing `Xxx as XxxIcon` convention.

```tsx
import {
Visibility as ViewIcon,
Delete as DeleteIcon,
Archive as ArchiveIcon,
NotificationsActive as NotificationsActiveIcon,
} from '@mui/icons-material';
```

Imports: `NotificationsActive as NotificationsActiveIcon` from `@mui/icons-material`.

## Task 2: Rewrite `formatDaysOverdue` to the two-state bell/blank behavior

**Files:**
- Modify: `client/src/modules/invoices/components/InvoiceTable.tsx`

**Why:** The current helper (lines 225-268) has three branches that all render
text (a dash for `0`, and `{daysOverdue} days` for the `>85` and fallback cases).
IA-525 redefines the cell to show only a red bell at `>= 270` and nothing below
that, so all existing branches must be replaced by the new logic.

- [ ] **Step 1: Replace the entire `formatDaysOverdue` body with the threshold check**

Replace the whole function (lines 225-268, from the `// Format days overdue …`
comment through the closing `};`). Return `null` when `daysOverdue = 270` return the red `NotificationsActiveIcon`
colored with `theme.palette.invoiceStatus.overdue`, wrapped in a `Tooltip` for
accessible context. Keep the `daysOverdue: number` parameter signature unchanged so
the call site at line 505 (`formatDaysOverdue(invoice.daysOverdue)`) is unaffected.

```tsx
// Render a red bell icon for invoices overdue by at least 270 days; blank otherwise
const formatDaysOverdue = (daysOverdue: number) => {
if (daysOverdue
({ color: theme.palette.invoiceStatus.overdue })}
/>

);
};
```

Key points: return `null` (not an empty ``) for the blank case so the
cell is truly empty. The `sx` callback receives `theme`, mirroring the existing
pattern at lines 239 and 256; `theme.palette.invoiceStatus.overdue` is the
established overdue red. The parameter type and name stay `daysOverdue: number`;
no change to the call site (`InvoiceTable.tsx:505`). `Tooltip` requires a single
focusable/forwardRef child — a single MUI icon satisfies this.